### PR TITLE
Avoid fatal error on ServiceNotFoundException

### DIFF
--- a/ps_mbo.php
+++ b/ps_mbo.php
@@ -330,18 +330,26 @@ class ps_mbo extends Module
     {
         /** @var UrlGeneratorInterface $router */
         $router = $this->get('router');
+
+        try {
+            $recommendedModulesUrl = $router->generate(
+                'admin_mbo_recommended_modules',
+                [
+                    'tabClassName' => Tools::getValue('controller'),
+                ]
+            );
+        } catch (Exception $exception) {
+            // Avoid fatal errors on ServiceNotFoundException
+            return '';
+        }
+
         $this->smarty->assign([
             'shouldAttachRecommendedModulesAfterContent' => $this->shouldAttachRecommendedModulesAfterContent(),
             'shouldAttachRecommendedModulesButton' => $this->shouldAttachRecommendedModulesButton(),
             'shouldUseLegacyTheme' => $this->isAdminLegacyContext(),
             'recommendedModulesTitleTranslated' => $this->trans('Recommended Modules and Services'),
             'recommendedModulesCloseTranslated' => $this->trans('Close', [], 'Admin.Actions'),
-            'recommendedModulesUrl' => $router->generate(
-                'admin_mbo_recommended_modules',
-                [
-                    'tabClassName' => Tools::getValue('controller'),
-                ]
-            ),
+            'recommendedModulesUrl' => $recommendedModulesUrl,
         ]);
 
         return $this->fetch('module:ps_mbo/views/templates/hook/recommended-modules.tpl');


### PR DESCRIPTION
### Avoid fatal error on ServiceNotFoundException

I suppose this error is due to cache, probably server cache like OPcache.
Because PrestaShop cache should be cleared on Module install in normal case.

#### /var/logs/prod.log

[2020-05-28 13:01:20] request.CRITICAL: Uncaught PHP Exception Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException: "You have requested a non-existent service "mbo.tab.collection.provider"." at /vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Container.php line 348 {"exception":"[object] (Symfony\\Component\\DependencyInjection\\Exception\\ServiceNotFoundException(code: 0): You have requested a non-existent service \"mbo.tab.collection.provider\". at /vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Container.php:348)"} []


#### Fatal error
```
Unable to generate a URL for the named route "admin_mbo_catalog_module" as such route does not exist.

in var/cache/dev/appDevDebugProjectContainerUrlGenerator.php (line 387)

appDevDebugProjectContainerUrlGenerator->generate('admin_mbo_catalog_module', array(), 0) in vendor/symfony/symfony/src/Symfony/Component/Routing/Router.php (line 240)

Router->generate('admin_mbo_catalog_module', array(), 0) in src/PrestaShopBundle/Service/Routing/Router.php (line 49)

Router->generate('admin_mbo_catalog_module', array(), 0) in src/PrestaShopBundle/Routing/Converter/LegacyUrlConverter.php (line 92)

LegacyUrlConverter->convertByParameters(array()) in classes/Link.php (line 822)

LinkCore->getAdminLink('AdminPsMboModule') in classes/controller/AdminController.php (line 2048)

AdminControllerCore->getTabs('48', 3) in classes/controller/AdminController.php (line 2049)

AdminControllerCore->getTabs('43', 2) in classes/controller/AdminController.php (line 2049)

AdminControllerCore->getTabs('42', 1) in classes/controller/AdminController.php (line 2049)

AdminControllerCore->getTabs() in classes/controller/AdminController.php (line 1919)

AdminControllerCore->initHeader() in classes/controller/Controller.php (line 288)

ControllerCore->run() in classes/Dispatcher.php (line 515)

DispatcherCore->dispatch() in admin-dev/index.php (line 97)
```

#### Related reports
1. https://www.prestashop.com/forums/topic/1024326-prestashop-marketplace-in-your-back-office/
2. https://www.prestashop.com/forums/topic/1024187-errore-modulo/
3. https://www.prestashop.com/forums/topic/1024399-error-500-back-office-after-updating/