### PR TITLE
Prevent double escaping module descriptions

### DIFF
--- a/src/ModuleCollectionDataProvider.php
+++ b/src/ModuleCollectionDataProvider.php
@@ -122,7 +122,7 @@ class ModuleCollectionDataProvider
             if ($module->get('author') === ModuleRepository::PARTNER_AUTHOR) {
                 $module->set('type', 'addonsPartner');
             }
-            
+
             if (!empty($module->get('description'))) {
                 $module->set('description', html_entity_decode($module->get('description'), ENT_QUOTES));
             }

--- a/src/ModuleCollectionDataProvider.php
+++ b/src/ModuleCollectionDataProvider.php
@@ -122,6 +122,10 @@ class ModuleCollectionDataProvider
             if ($module->get('author') === ModuleRepository::PARTNER_AUTHOR) {
                 $module->set('type', 'addonsPartner');
             }
+            
+            if (!empty($module->get('description'))) {
+                $module->set('description', html_entity_decode($module->get('description'), ENT_QUOTES));
+            }
 
             $module->fillLogo();
             $data[$module->get('name')] = $this->modulePresenter->present($module);


### PR DESCRIPTION
This PR aims to fix this bug : https://github.com/PrestaShop/PrestaShop/issues/21298

Because the addons API returns already escaped module descriptions, we should decode it first so it gets escaped once again in the view.