### PR TITLE
Fix links when the module is disabled

### DIFF
--- a/ps_mbo.php
+++ b/ps_mbo.php
@@ -163,7 +163,17 @@ class ps_mbo extends Module
     public function install()
     {
         return parent::install()
-            && $this->registerHook(static::HOOKS)
+            && $this->registerHook(static::HOOKS);
+    }
+
+    /**
+     * Enable Module.
+     *
+     * @return bool
+     */
+    public function enable($force_all = false)
+    {
+        return parent::enable($force_all)
             && $this->installTabs();
     }
 
@@ -232,13 +242,13 @@ class ps_mbo extends Module
     }
 
     /**
-     * Uninstall Module.
+     * Disable Module.
      *
      * @return bool
      */
-    public function uninstall()
+    public function disable($force_all = false)
     {
-        return parent::uninstall()
+        return parent::disable($force_all)
             && $this->uninstallTabs();
     }
 


### PR DESCRIPTION
In 1.7.6.x when you disable ps_mbo, the following menu items are still using the ps_mbo's links:
- Module Catalog
- Module Selections
- Themes Catalog

In 1.7.7.x the behavior is a bit different as it's not using ps_mbo's ones but *Themes Catalog* disapears, *Module Catalog* link is wrong and so *Module Selections* is not accessible.

This PR should fixes https://github.com/PrestaShop/PrestaShop/issues/21588

##### How to test

Disable ps_mbo & check that *Module Catalog*, *Module Selections* & *Themes Catalog* are still present and that their links are core's ones, not ps_mbo's.