### PR TITLE
Change contentContainer selector to more generic of new theme

### DIFF
--- a/views/js/recommended-modules.js
+++ b/views/js/recommended-modules.js
@@ -142,14 +142,7 @@ var mbo = {};
         recommendedModulesRequest.done(function(data) {
           var recommendedModulesContainer = new RecommendedModulesContainer(config, data.content);
 
-          let contentContainer;
-          if (pageMap.contentContainer instanceof Array) {
-            contentContainer = pageMap.contentContainer.find(element => $(element).length);
-          } else {
-            contentContainer = pageMap.contentContainer;
-          }
-
-          $(contentContainer).append(recommendedModulesContainer.getMarkup());
+          $(pageMap.contentContainer).first().append(recommendedModulesContainer.getMarkup());
         });
 
         recommendedModulesRequest.fail(function(jqXHR, textStatus, errorThrown) {
@@ -160,14 +153,7 @@ var mbo = {};
           }
           var recommendedModulesContainer = new RecommendedModulesContainer(config, content);
 
-          let contentContainer;
-          if (pageMap.contentContainer instanceof Array) {
-            contentContainer = pageMap.contentContainer.find(element => $(element).length);
-          } else {
-            contentContainer = pageMap.contentContainer;
-          }
-
-          $(contentContainer).append(recommendedModulesContainer.getMarkup().get(0).outerHTML);
+          $(pageMap.contentContainer).first().append(recommendedModulesContainer.getMarkup().get(0).outerHTML);
         });
       }
 

--- a/views/js/recommended-modules.js
+++ b/views/js/recommended-modules.js
@@ -40,7 +40,10 @@ var mbo = {};
     toolbarLastElement: '.toolbar-icons a:last-of-type',
     recommendedModulesButton: '#recommended-modules-button',
     oldButton: '#page-header-desc-configuration-modules-list',
-    contentContainer: '#main-div .content-div .row:last .col',
+    contentContainer: [
+      '#main-div .content-div .container:last',
+      '#main-div .content-div .col:last',
+    ],
     modulesListModal: '#modules_list_container',
     modulesListModalContainer: '#main-div .content-div',
     modulesListModalContent: '#modules_list_container_tab_modal',
@@ -142,7 +145,14 @@ var mbo = {};
         recommendedModulesRequest.done(function(data) {
           var recommendedModulesContainer = new RecommendedModulesContainer(config, data.content);
 
-          $(pageMap.contentContainer).append(recommendedModulesContainer.getMarkup());
+          let contentContainer;
+          if (pageMap.contentContainer instanceof Array) {
+            contentContainer = pageMap.contentContainer.find(element => $(element).length);
+          } else {
+            contentContainer = pageMap.contentContainer;
+          }
+
+          $(contentContainer).append(recommendedModulesContainer.getMarkup());
         });
 
         recommendedModulesRequest.fail(function(jqXHR, textStatus, errorThrown) {
@@ -153,7 +163,14 @@ var mbo = {};
           }
           var recommendedModulesContainer = new RecommendedModulesContainer(config, content);
 
-          $(pageMap.contentContainer).append(recommendedModulesContainer.getMarkup().get(0).outerHTML);
+          let contentContainer;
+          if (pageMap.contentContainer instanceof Array) {
+            contentContainer = pageMap.contentContainer.find(element => $(element).length);
+          } else {
+            contentContainer = pageMap.contentContainer;
+          }
+
+          $(contentContainer).append(recommendedModulesContainer.getMarkup().get(0).outerHTML);
         });
       }
 

--- a/views/js/recommended-modules.js
+++ b/views/js/recommended-modules.js
@@ -40,7 +40,7 @@ var mbo = {};
     toolbarLastElement: '.toolbar-icons a:last-of-type',
     recommendedModulesButton: '#recommended-modules-button',
     oldButton: '#page-header-desc-configuration-modules-list',
-    contentContainer: '#main-div .content-div .container:last',
+    contentContainer: '#main-div .content-div .row:last .col',
     modulesListModal: '#modules_list_container',
     modulesListModalContainer: '#main-div .content-div',
     modulesListModalContent: '#modules_list_container_tab_modal',

--- a/views/js/recommended-modules.js
+++ b/views/js/recommended-modules.js
@@ -40,10 +40,7 @@ var mbo = {};
     toolbarLastElement: '.toolbar-icons a:last-of-type',
     recommendedModulesButton: '#recommended-modules-button',
     oldButton: '#page-header-desc-configuration-modules-list',
-    contentContainer: [
-      '#main-div .content-div .container:last',
-      '#main-div .content-div .col:last',
-    ],
+    contentContainer: '#main-div .content-div .container:last, #main-div .content-div .js-content-col:last'
     modulesListModal: '#modules_list_container',
     modulesListModalContainer: '#main-div .content-div',
     modulesListModalContent: '#modules_list_container_tab_modal',


### PR DESCRIPTION
The current selector was made to fit specifically to the payment methods page, but with PrestaShop/PrestaShop#20737 carriers page is being migrated and this has to use more generic selector. This change generated HTML, but not how the page looks like.