### PR TITLE
Fix the category dropdown on the module catalog page

### DIFF
--- a/views/templates/admin/controllers/module_catalog/includes/dropdown_categories_catalog.html.twig
+++ b/views/templates/admin/controllers/module_catalog/includes/dropdown_categories_catalog.html.twig
@@ -33,14 +33,13 @@
     </div>
 
     <div class="ps-dropdown-menu dropdown-menu module-category-selector items-list js-items-list" aria-labelledby="{{refMenu}}">
-        <a class="dropdown-item module-category-reset">
+        <a class="dropdown-item module-category-menu module-category-reset">
           {{ 'All categories'|trans({}, 'Admin.Modules.Feature') }}
         </a>
 
         {% for subMenu in menu.subMenu %}
-          <a 
-            class="dropdown-item" 
-            class="module-category-menu"
+          <a
+            class="dropdown-item module-category-menu"
             {% if subMenu.tab %}data-category-tab="{{subMenu.tab}}"{% endif %}
             data-category-ref="{{subMenu.refMenu}}"
             data-category-display-name="{{subMenu.name}}"


### PR DESCRIPTION
JS actions on select/reset are based on this class `module-category-menu`.
Just re-add it correctly on nodes.