### PR TITLE
Update DOM selector after changes occurs on pages

### DIFF
--- a/views/js/recommended-modules.js
+++ b/views/js/recommended-modules.js
@@ -40,7 +40,7 @@ var mbo = {};
     toolbarLastElement: '.toolbar-icons a:last-of-type',
     recommendedModulesButton: '#recommended-modules-button',
     oldButton: '#page-header-desc-configuration-modules-list',
-    contentContainer: '#main-div .content-div',
+    contentContainer: '#main-div .content-div > .row:last > .col-sm-12',
     modulesListModal: '#modules_list_container',
     modulesListModalContainer: '#main-div .content-div',
     modulesListModalContent: '#modules_list_container_tab_modal',

--- a/views/js/recommended-modules.js
+++ b/views/js/recommended-modules.js
@@ -40,7 +40,7 @@ var mbo = {};
     toolbarLastElement: '.toolbar-icons a:last-of-type',
     recommendedModulesButton: '#recommended-modules-button',
     oldButton: '#page-header-desc-configuration-modules-list',
-    contentContainer: '#main-div .content-div .container:last',
+    contentContainer: '#main-div .content-div',
     modulesListModal: '#modules_list_container',
     modulesListModalContainer: '#main-div .content-div',
     modulesListModalContent: '#modules_list_container_tab_modal',


### PR DESCRIPTION
Change the selector for new layout pages in order to refer to the global layout and not depend on each controllers.