### PR TITLE
[MBO-15] Fetch data for dashboard news

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.php_cs.cache
+.php*.cache
 config_*.xml
 /vendor/
 !/vendor/index.php

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
   "require-dev": {
     "prestashop/php-dev-tools": "^4",
     "phpunit/phpunit": "^8.5",
-    "mockery/mockery": "^1.3"
+    "mockery/mockery": "^1.3",
+    "phpstan/phpstan": "^1.4"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "265469dc12dd6001ef2bdc430f22e643",
+    "content-hash": "1629088887a9254477e9c8f268ad3997",
     "packages": [
         {
             "name": "composer/semver",
@@ -3528,6 +3528,70 @@
                 "source": "https://github.com/phpspec/prophecy/tree/1.14.0"
             },
             "time": "2021-09-10T09:02:12+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.4.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "8a7761f1c520e0dad6e04d862fdc697445457cfe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8a7761f1c520e0dad6e04d862fdc697445457cfe",
+                "reference": "8a7761f1c520e0dad6e04d862fdc697445457cfe",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "source": "https://github.com/phpstan/phpstan/tree/1.4.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpstan",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-02-06T12:56:13+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/config/routes.yml
+++ b/config/routes.yml
@@ -14,8 +14,6 @@ addons:
   resource: './routes/addons.yml'
   prefix: /mbo/addons
 
-admin_mbo_dashboard_blog_rss:
-  path: /mbo/dashboard/news/rss
-  methods: [GET]
-  defaults:
-    _controller: mbo.controller.dashboard.news:getBlogRssAction
+dashboard:
+  resource: './routes/dashboard.yml'
+  prefix: /mbo/dashboard

--- a/config/routes.yml
+++ b/config/routes.yml
@@ -13,3 +13,9 @@ themes_catalog:
 addons:
   resource: './routes/addons.yml'
   prefix: /mbo/addons
+
+admin_mbo_dashboard_blog_rss:
+  path: /mbo/dashboard/news/rss
+  methods: [GET]
+  defaults:
+    _controller: mbo.controller.dashboard.news:getBlogRssAction

--- a/config/routes/dashboard.yml
+++ b/config/routes/dashboard.yml
@@ -1,0 +1,7 @@
+
+
+admin_mbo_dashboard_blog_rss:
+  path: /news/rss
+  methods: [GET]
+  defaults:
+    _controller: mbo.controller.dashboard.news:getBlogRssAction

--- a/config/services.yml
+++ b/config/services.yml
@@ -52,3 +52,8 @@ services:
       - '@mbo.addon.module.data_provider.addons'
       - '@prestashop.core.admin.data_provider.module_interface'
       - '@prestashop.module.manager'
+
+  mbo.controller.dashboard.news:
+    class: 'PrestaShop\Module\Mbo\Controller\Admin\DashboardNewsController'
+    arguments:
+      - '@mbo.service.news.provider'

--- a/config/services.yml
+++ b/config/services.yml
@@ -56,4 +56,5 @@ services:
   mbo.controller.dashboard.news:
     class: 'PrestaShop\Module\Mbo\Controller\Admin\DashboardNewsController'
     arguments:
+      - '@prestashop.adapter.legacy.context'
       - '@mbo.service.news.provider'

--- a/config/services/circuit_breaker.yml
+++ b/config/services/circuit_breaker.yml
@@ -1,0 +1,20 @@
+services:
+  mbo.circuit_breaker.advanced_factory:
+    class: PrestaShop\CircuitBreaker\AdvancedCircuitBreakerFactory
+
+  mbo.news.circuit_breaker.settings:
+    class: PrestaShop\CircuitBreaker\FactorySettings
+    arguments:
+      - !php/const \PrestaShop\Module\Mbo\Service\News\NewsDataProvider::CLOSED_ALLOWED_FAILURES
+      - !php/const \PrestaShop\Module\Mbo\Service\News\NewsDataProvider::CLOSED_TIMEOUT_SECONDS
+      - !php/const \PrestaShop\Module\Mbo\Service\News\NewsDataProvider::OPEN_THRESHOLD_SECONDS
+    calls:
+      - [ 'setStrippedFailures', [ !php/const \PrestaShop\Module\Mbo\Service\News\NewsDataProvider::OPEN_ALLOWED_FAILURES ] ]
+      - [ 'setStrippedTimeout', [ !php/const \PrestaShop\Module\Mbo\Service\News\NewsDataProvider::OPEN_TIMEOUT_SECONDS ] ]
+      - [ 'setStorage', [ '@prestashop.core.circuit_breaker.storage' ] ]
+
+  mbo.news.circuit_breaker:
+    class: 'PrestaShop\CircuitBreaker\Contract\CircuitBreakerInterface'
+    factory: [ "@mbo.circuit_breaker.advanced_factory", create ]
+    arguments:
+      - "@mbo.news.circuit_breaker.settings"

--- a/config/services/news.yml
+++ b/config/services/news.yml
@@ -1,0 +1,13 @@
+services:
+  _defaults:
+    public: true
+
+  mbo.service.news.provider:
+    class: PrestaShop\Module\Mbo\Service\News\NewsDataProvider
+    arguments:
+      - "@mbo.news.circuit_breaker"
+      - "@prestashop.adapter.data_provider.country"
+      - "@prestashop.adapter.tools"
+      - "@prestashop.adapter.legacy.configuration"
+      - "@prestashop.adapter.validate"
+      - "@=service('prestashop.adapter.legacy.context').getContext().mode"

--- a/src/Controller/Admin/DashboardNewsController.php
+++ b/src/Controller/Admin/DashboardNewsController.php
@@ -32,7 +32,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 class DashboardNewsController extends FrameworkBundleAdminController
 {
     /**
-     * @var \PrestaShop\PrestaShop\Adapter\LegacyContext
+     * @var LegacyContext
      */
     protected $context;
 

--- a/src/Controller/Admin/DashboardNewsController.php
+++ b/src/Controller/Admin/DashboardNewsController.php
@@ -21,25 +21,20 @@ declare(strict_types=1);
 
 namespace PrestaShop\Module\Mbo\Controller\Admin;
 
-use AdminController;
-use PrestaShop\Module\Mbo\ExternalContentProvider\ExternalContentProviderInterface;
 use PrestaShop\Module\Mbo\Service\News\NewsDataProvider;
-use Symfony\Component\HttpFoundation\RequestStack;
+use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**
- * Responsible of "Improve > Design > Themes Catalog" page display.
+ * Responsible of loading the news in the dashboard widget.
  */
-class DashboardNewsController extends AdminController
+class DashboardNewsController extends FrameworkBundleAdminController
 {
     /**
-     * @var RequestStack
+     * @var \PrestaShop\PrestaShop\Adapter\LegacyContext
      */
-    protected $requestStack;
-
-    /**
-     * @var ExternalContentProviderInterface
-     */
-    protected $externalContentProvider;
+    protected $context;
 
     /**
      * @var NewsDataProvider
@@ -47,24 +42,22 @@ class DashboardNewsController extends AdminController
     protected $newsDataProvider;
 
     /**
-     * @param \PrestaShop\Module\Mbo\Service\News\NewsDataProvider $newsDataProvider
+     * @param LegacyContext $context
      */
     public function __construct(
+        LegacyContext $context,
         NewsDataProvider $newsDataProvider
     ) {
         parent::__construct();
+        $this->context = $context;
         $this->newsDataProvider = $newsDataProvider;
     }
 
     /**
      * Returns last news from the blog
      */
-    public function displayAjaxGetBlogRss()
+    public function getBlogRssAction()
     {
-        $return = $this->newsDataProvider->getData($this->context->language->iso_code);
-
-        // Response
-        header('Content-Type: application/json');
-        $this->ajaxRender(json_encode($return));
+        return new JsonResponse($this->newsDataProvider->getData($this->context->getLanguage()->iso_code));
     }
 }

--- a/src/Controller/Admin/DashboardNewsController.php
+++ b/src/Controller/Admin/DashboardNewsController.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\Module\Mbo\Controller\Admin;
+
+use AdminController;
+use PrestaShop\Module\Mbo\ExternalContentProvider\ExternalContentProviderInterface;
+use PrestaShop\Module\Mbo\Service\News\NewsDataProvider;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Responsible of "Improve > Design > Themes Catalog" page display.
+ */
+class DashboardNewsController extends AdminController
+{
+    /**
+     * @var RequestStack
+     */
+    protected $requestStack;
+
+    /**
+     * @var ExternalContentProviderInterface
+     */
+    protected $externalContentProvider;
+
+    /**
+     * @var NewsDataProvider
+     */
+    protected $newsDataProvider;
+
+    /**
+     * @param \PrestaShop\Module\Mbo\Service\News\NewsDataProvider $newsDataProvider
+     */
+    public function __construct(
+        NewsDataProvider $newsDataProvider
+    ) {
+        parent::__construct();
+        $this->newsDataProvider = $newsDataProvider;
+    }
+
+    /**
+     * Returns last news from the blog
+     */
+    public function displayAjaxGetBlogRss()
+    {
+        $return = $this->newsDataProvider->getData($this->context->language->iso_code);
+
+        // Response
+        header('Content-Type: application/json');
+        $this->ajaxRender(json_encode($return));
+    }
+}

--- a/src/Service/News/NewsDataProvider.php
+++ b/src/Service/News/NewsDataProvider.php
@@ -148,7 +148,7 @@ class NewsDataProvider
                 $analytics_params['utm_content'] = 'cloud';
             }
 
-            $url_query = parse_url((string) $item->link, PHP_URL_QUERY);
+            $url_query = parse_url((string) $item->link, PHP_URL_QUERY) ?? '';
             parse_str($url_query, $link_query_params);
             $full_url_params = array_merge($link_query_params, $analytics_params);
             $base_url = explode('?', (string) $item->link);

--- a/src/Service/News/NewsDataProvider.php
+++ b/src/Service/News/NewsDataProvider.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\Module\Mbo\Service\News;
 
-use ContextCore as Context;
+use Context;
 use PrestaShop\CircuitBreaker\Contract\CircuitBreakerInterface;
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\Country\CountryDataProvider;

--- a/src/Service/News/NewsDataProvider.php
+++ b/src/Service/News/NewsDataProvider.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\Module\Mbo\Service\News;
+
+use ContextCore as Context;
+use PrestaShop\CircuitBreaker\Contract\CircuitBreakerInterface;
+use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Adapter\Country\CountryDataProvider;
+use PrestaShop\PrestaShop\Adapter\Tools;
+use PrestaShop\PrestaShop\Adapter\Validate;
+use stdClass;
+
+/**
+ * Provide the news from https://www.prestashop.com/blog/
+ */
+class NewsDataProvider
+{
+    public const NUM_ARTICLES = 2;
+
+    public const CLOSED_ALLOWED_FAILURES = 3;
+    public const CLOSED_TIMEOUT_SECONDS = 3;
+
+    public const OPEN_ALLOWED_FAILURES = 3;
+    public const OPEN_TIMEOUT_SECONDS = 3;
+    public const OPEN_THRESHOLD_SECONDS = 86400; // 24 hours
+
+    /**
+     * @var CircuitBreakerInterface
+     */
+    private $circuitBreaker;
+
+    /**
+     * @var Configuration
+     */
+    private $configuration;
+
+    /**
+     * @var int
+     */
+    private $contextMode;
+
+    /**
+     * @var CountryDataProvider
+     */
+    private $countryDataProvider;
+
+    /**
+     * @var Tools
+     */
+    private $tools;
+
+    /**
+     * @var Validate
+     */
+    private $validate;
+
+    /**
+     * NewsDataProvider constructor.
+     *
+     * @param CircuitBreakerInterface $circuitBreaker
+     * @param CountryDataProvider $countryDataProvider
+     * @param Tools $tools
+     * @param Configuration $configuration
+     * @param Validate $validate
+     * @param int $contextMode
+     */
+    public function __construct(
+        CircuitBreakerInterface $circuitBreaker,
+        CountryDataProvider $countryDataProvider,
+        Tools $tools,
+        Configuration $configuration,
+        Validate $validate,
+        int $contextMode
+    ) {
+        $this->circuitBreaker = $circuitBreaker;
+        $this->configuration = $configuration;
+        $this->contextMode = $contextMode;
+        $this->countryDataProvider = $countryDataProvider;
+        $this->tools = $tools;
+        $this->validate = $validate;
+    }
+
+    /**
+     * @param string $isoCode
+     *
+     * @return array
+     */
+    public function getData(string $isoCode): array
+    {
+        $data = ['has_errors' => true, 'rss' => []];
+        $apiUrl = $this->configuration->get('_PS_API_URL_');
+
+        $blogXMLResponse = $this->circuitBreaker->call($apiUrl . '/rss/blog/blog-' . $isoCode . '.xml');
+
+        if (empty($blogXMLResponse)) {
+            $data['has_errors'] = false;
+
+            return $data;
+        }
+
+        $rss = @simplexml_load_string($blogXMLResponse);
+        if (!$rss) {
+            return $data;
+        }
+
+        $articles_limit = self::NUM_ARTICLES;
+
+        $shop_default_country_id = (int) $this->configuration->get('PS_COUNTRY_DEFAULT');
+        $shop_default_iso_country = mb_strtoupper($this->countryDataProvider->getIsoCodebyId($shop_default_country_id), 'utf-8');
+        $analytics_params = [
+            'utm_source' => 'back-office',
+            'utm_medium' => 'rss',
+            'utm_campaign' => 'back-office-' . $shop_default_iso_country,
+        ];
+
+        /** @var stdClass $item */
+        foreach ($rss->channel->item as $item) {
+            if ($articles_limit === 0) {
+                break;
+            }
+            if (!$this->validate->isCleanHtml((string) $item->title)
+                || !$this->validate->isCleanHtml((string) $item->description)
+                || empty($item->link)
+                || empty($item->title)) {
+                continue;
+            }
+            $analytics_params['utm_content'] = 'download';
+            if (in_array($this->contextMode, [Context::MODE_HOST, Context::MODE_HOST_CONTRIB])) {
+                $analytics_params['utm_content'] = 'cloud';
+            }
+
+            $url_query = parse_url((string) $item->link, PHP_URL_QUERY);
+            parse_str($url_query, $link_query_params);
+            $full_url_params = array_merge($link_query_params, $analytics_params);
+            $base_url = explode('?', (string) $item->link);
+            $base_url = (string) $base_url[0];
+            $article_link = $base_url . '?' . http_build_query($full_url_params);
+            $date = strtotime((string) $item->pubDate);
+            $data['rss'][] = [
+                'date' => $this->tools->displayDate(date('Y-m-d H:i:s', $date), null, false),
+                'title' => htmlentities((string) $item->title, ENT_QUOTES, 'utf-8'),
+                'short_desc' => $this->tools->truncateString(strip_tags((string) $item->description), 150),
+                'link' => (string) $article_link,
+            ];
+            --$articles_limit;
+        }
+        $data['has_errors'] = false;
+
+        return $data;
+    }
+}

--- a/src/Traits/Hooks/UseDashboardZoneThree.php
+++ b/src/Traits/Hooks/UseDashboardZoneThree.php
@@ -27,6 +27,18 @@ use ToolsCore as Tools;
 trait UseDashboardZoneThree
 {
     /**
+     * @return void
+     *
+     * @throws \Exception
+     */
+    public function bootUseDashboardZoneThree(): void
+    {
+        if (method_exists($this, 'addAdminControllerMedia')) {
+            $this->addAdminControllerMedia('loadMediaForDashboardColumnThree');
+        }
+    }
+
+    /**
      * Display addons data & links in the third column of the dashboard
      *
      * @param array $params
@@ -69,5 +81,20 @@ trait UseDashboardZoneThree
         ];
 
         return $links[$languageCode] ?? $links['en'];
+    }
+
+    /**
+     * Add JS and CSS file
+     *
+     * @return void
+     *
+     * @see \PrestaShop\Module\Mbo\Traits\Hooks\UseAdminControllerSetMedia
+     */
+    protected function loadMediaForDashboardColumnThree(): void
+    {
+        if (Tools::getValue('controller') === 'AdminDashboard') {
+            $this->context->controller->addJs($this->getPathUri() . 'views/js/dashboard-news.js?v=' . $this->version);
+            $this->context->controller->addCSS($this->getPathUri() . 'views/css/dashboard-news.css?v=' . $this->version);
+        }
     }
 }

--- a/tests/phpstan/bootstrap.php
+++ b/tests/phpstan/bootstrap.php
@@ -17,10 +17,12 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
+
+use Composer\Autoload\ClassLoader;
+
 $rootDir = getenv('_PS_ROOT_DIR_');
 if (!$rootDir) {
-    echo '[ERROR] Define _PS_ROOT_DIR_ with the path to PrestaShop folder' . PHP_EOL;
-    exit(1);
+    $rootDir = __DIR__ . '/../../../../';
 }
 
 $pathToModuleRoot = __DIR__ . '/../../';
@@ -39,11 +41,11 @@ require_once $rootDir . '/config/bootstrap.php';
 // Make sure loader php-parser is coming from php stan composer
 
 // 1- Use with Docker container
-$loader = new \Composer\Autoload\ClassLoader();
+$loader = new ClassLoader();
 $loader->setPsr4('PhpParser\\', ['/composer/vendor/nikic/php-parser/lib/PhpParser']);
 $loader->register(true);
 // 2- Use with PHPStan phar
-$loader = new \Composer\Autoload\ClassLoader();
+$loader = new ClassLoader();
 // Contains the vendor in phar, like "phar://phpstan.phar/vendor"
 $loader->setPsr4('PhpParser\\', ['phar://' . dirname($_SERVER['PATH_TRANSLATED']) . '/../phpstan/phpstan-shim/phpstan.phar/vendor/nikic/php-parser/lib/PhpParser/']);
 $loader->register(true);

--- a/tests/phpstan/phpstan-nightly.neon
+++ b/tests/phpstan/phpstan-nightly.neon
@@ -8,6 +8,6 @@ parameters:
     - _PS_VERSION_
   ignoreErrors:
     - '#^Method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\) invoked with 2 parameters, 1 required\.$#'
-    - '~^Parameter #1 $modules of method PrestaShopBundle\\Service\\DataProvider\\Admin\\CategoriesProvider::getCategoriesMenu\(\) expects array|PrestaShop\\PrestaShop\\Core\\Addon\\AddonsCollection, PrestaShop\\Module\\Mbo\\Modules\\Collection given\.$~'
+    - '~^Parameter #1 \$modules of method PrestaShopBundle\\Service\\DataProvider\\Admin\\CategoriesProvider::getCategoriesMenu\(\) expects array|PrestaShop\\PrestaShop\\Core\\Addon\\AddonsCollection, PrestaShop\\Module\\Mbo\\Modules\\Collection given\.$~'
 
   level: 5

--- a/views/css/dashboard-news.css
+++ b/views/css/dashboard-news.css
@@ -1,0 +1,25 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+.dash_news h3 {
+  font-size: 14px !important;
+}
+.dash_news h3 i {
+  font-size: 20px;
+  color: #6c868e;
+}

--- a/views/js/dashboard-news.js
+++ b/views/js/dashboard-news.js
@@ -21,10 +21,10 @@
 
 function getDashboardMBONewsBlogRss() {
   $.ajax({
-    url : mbo_dashboard_news_ajax_url,
-    data : {
-      ajax:true,
-      action:'getBlogRss'
+    url: mbo_dashboard_news_ajax_url,
+    data: {
+      ajax: true,
+      action: 'getBlogRss'
     },
     dataType: 'json',
     success : function(jsonData) {

--- a/views/js/dashboard-news.js
+++ b/views/js/dashboard-news.js
@@ -1,0 +1,45 @@
+'use strict';
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+
+function getBlogRss() {
+  $.ajax({
+    url : dashboard_ajax_url,
+    data : {
+      ajax:true,
+      action:'getBlogRss'
+    },
+    dataType: 'json',
+    success : function(jsonData) {
+      if (typeof jsonData !== 'undefined' && jsonData !== null && !jsonData.has_errors) {
+        for (var article in jsonData.rss) {
+          var article_html = '<article><h4><a href="'+jsonData.rss[article].link+'" target="_blank" rel="noopener noreferrer nofollow" onclick="return !window.open(this.href);">'+jsonData.rss[article].title+'</a></h4><span class="dash-news-date text-muted">'+jsonData.rss[article].date+'</span><p>'+jsonData.rss[article].short_desc+' <a href="'+jsonData.rss[article].link+'">'+read_more+'</a><p></article><hr/>';
+          $('.dash_news .dash_news_content').append(article_html);
+        }
+      }
+      else {
+        $('.dash_news').hide();
+      }
+    }
+  });
+}
+
+
+getBlogRss();

--- a/views/js/dashboard-news.js
+++ b/views/js/dashboard-news.js
@@ -27,7 +27,7 @@ function getDashboardMBONewsBlogRss() {
       action: 'getBlogRss'
     },
     dataType: 'json',
-    success : function(jsonData) {
+    success: function(jsonData) {
       if (typeof jsonData !== 'undefined' && jsonData !== null && !jsonData.has_errors) {
         for (var article in jsonData.rss) {
           var article_html = '<article><h4><a href="'+jsonData.rss[article].link+'" target="_blank" rel="noopener noreferrer nofollow" onclick="return !window.open(this.href);">'+jsonData.rss[article].title+'</a></h4><span class="dash-news-date text-muted">'+jsonData.rss[article].date+'</span><p>'+jsonData.rss[article].short_desc+' <a href="'+jsonData.rss[article].link+'">'+mbo_dasboard_news_read_more+'</a><p></article><hr/>';

--- a/views/js/dashboard-news.js
+++ b/views/js/dashboard-news.js
@@ -19,7 +19,7 @@
  */
 
 
-function getBlogRss() {
+function getDashboardMBONewsBlogRss() {
   $.ajax({
     url : mbo_dashboard_news_ajax_url,
     data : {
@@ -41,5 +41,3 @@ function getBlogRss() {
   });
 }
 
-
-getBlogRss();

--- a/views/js/dashboard-news.js
+++ b/views/js/dashboard-news.js
@@ -19,9 +19,12 @@
  */
 
 
-function getDashboardMBONewsBlogRss() {
+function getDashboardMBONewsBlogRss(dashboardNewsAjaxUrl, translationsDashboardMbo) {
+  if(!dashboardNewsAjaxUrl || ! translationsDashboardMbo || !translationsDashboardMbo.new_read_more) {
+    return;
+  }
   $.ajax({
-    url: mbo_dashboard_news_ajax_url,
+    url: dashboardNewsAjaxUrl,
     data: {
       ajax: true,
       action: 'getBlogRss'
@@ -30,7 +33,7 @@ function getDashboardMBONewsBlogRss() {
     success: function(jsonData) {
       if (typeof jsonData !== 'undefined' && jsonData !== null && !jsonData.has_errors) {
         for (var article in jsonData.rss) {
-          var article_html = '<article><h4><a href="'+jsonData.rss[article].link+'" target="_blank" rel="noopener noreferrer nofollow" onclick="return !window.open(this.href);">'+jsonData.rss[article].title+'</a></h4><span class="dash-news-date text-muted">'+jsonData.rss[article].date+'</span><p>'+jsonData.rss[article].short_desc+' <a href="'+jsonData.rss[article].link+'">'+mbo_dasboard_news_read_more+'</a><p></article><hr/>';
+          var article_html = '<article><h4><a href="'+jsonData.rss[article].link+'" target="_blank" rel="noopener noreferrer nofollow" onclick="return !window.open(this.href);">'+jsonData.rss[article].title+'</a></h4><span class="dash-news-date text-muted">'+jsonData.rss[article].date+'</span><p>'+jsonData.rss[article].short_desc+' <a href="'+jsonData.rss[article].link+'">'+translationsDashboardMbo.new_read_more+'</a><p></article><hr/>';
           $('.dash_news .dash_news_content').append(article_html);
         }
       }

--- a/views/js/dashboard-news.js
+++ b/views/js/dashboard-news.js
@@ -21,7 +21,7 @@
 
 function getBlogRss() {
   $.ajax({
-    url : dashboard_ajax_url,
+    url : mbo_dashboard_news_ajax_url,
     data : {
       ajax:true,
       action:'getBlogRss'
@@ -30,7 +30,7 @@ function getBlogRss() {
     success : function(jsonData) {
       if (typeof jsonData !== 'undefined' && jsonData !== null && !jsonData.has_errors) {
         for (var article in jsonData.rss) {
-          var article_html = '<article><h4><a href="'+jsonData.rss[article].link+'" target="_blank" rel="noopener noreferrer nofollow" onclick="return !window.open(this.href);">'+jsonData.rss[article].title+'</a></h4><span class="dash-news-date text-muted">'+jsonData.rss[article].date+'</span><p>'+jsonData.rss[article].short_desc+' <a href="'+jsonData.rss[article].link+'">'+read_more+'</a><p></article><hr/>';
+          var article_html = '<article><h4><a href="'+jsonData.rss[article].link+'" target="_blank" rel="noopener noreferrer nofollow" onclick="return !window.open(this.href);">'+jsonData.rss[article].title+'</a></h4><span class="dash-news-date text-muted">'+jsonData.rss[article].date+'</span><p>'+jsonData.rss[article].short_desc+' <a href="'+jsonData.rss[article].link+'">'+mbo_dasboard_news_read_more+'</a><p></article><hr/>';
           $('.dash_news .dash_news_content').append(article_html);
         }
       }

--- a/views/templates/hook/dashboard-zone-three.tpl
+++ b/views/templates/hook/dashboard-zone-three.tpl
@@ -18,7 +18,7 @@
  *}
 
 <script>
-  var mbo_dashboard_news_ajax_url = '{$link->getAdminLink('DashboardNews')}';
+  var mbo_dashboard_news_ajax_url = '{$link->getAdminLink('DashboardNews', true, ["route" => "admin_mbo_dashboard_blog_rss"])}';
   var mbo_dasboard_news_read_more = '{l s='Read more' js=1}';
 
   getDashboardMBONewsBlogRss();

--- a/views/templates/hook/dashboard-zone-three.tpl
+++ b/views/templates/hook/dashboard-zone-three.tpl
@@ -20,6 +20,8 @@
 <script>
   var mbo_dashboard_news_ajax_url = '{$link->getAdminLink('DashboardNews')}';
   var mbo_dasboard_news_read_more = '{l s='Read more' js=1}';
+
+  getDashboardMBONewsBlogRss();
 </script>
 <section class="dash_news panel">
   <h3><i class="icon-rss"></i> {l s='PrestaShop News' d='Modules.Mbo.Dashboardzonethree'}</h3>

--- a/views/templates/hook/dashboard-zone-three.tpl
+++ b/views/templates/hook/dashboard-zone-three.tpl
@@ -18,10 +18,14 @@
  *}
 
 <script>
-  var mbo_dashboard_news_ajax_url = '{$link->getAdminLink('DashboardNews', true, ["route" => "admin_mbo_dashboard_blog_rss"])}';
-  var mbo_dasboard_news_read_more = '{l s='Read more' js=1}';
+  var dashboardNewsAjaxUrl = '{$link->getAdminLink('DashboardNews', true, ["route" => "admin_mbo_dashboard_blog_rss"])}';
+  var translationsDashboardMbo = {
+    new_read_more: '{l s='Read more' js=1}',
+  }
 
-  getDashboardMBONewsBlogRss();
+  if('function' === typeof getDashboardMBONewsBlogRss) {
+    getDashboardMBONewsBlogRss(dashboardNewsAjaxUrl, translationsDashboardMbo);
+  }
 </script>
 <section class="dash_news panel">
   <h3><i class="icon-rss"></i> {l s='PrestaShop News' d='Modules.Mbo.Dashboardzonethree'}</h3>

--- a/views/templates/hook/dashboard-zone-three.tpl
+++ b/views/templates/hook/dashboard-zone-three.tpl
@@ -17,6 +17,10 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  *}
 
+<script>
+  var mbo_dashboard_news_ajax_url = '{$link->getAdminLink('DashboardNews')}';
+  var mbo_dasboard_news_read_more = '{l s='Read more' js=1}';
+</script>
 <section class="dash_news panel">
   <h3><i class="icon-rss"></i> {l s='PrestaShop News' d='Modules.Mbo.Dashboardzonethree'}</h3>
   <div class="dash_news_content"></div>


### PR DESCRIPTION
Re-implement the removed code to fetch the blog/rss data in the dashboard.

See : https://github.com/PrestaShop/PrestaShop/pull/27444#pullrequestreview-870252502

Fixes : [#MBO-25](https://forge.prestashop.com/browse/MBO-25)