### PR TITLE
[MBO-13] Add "See more" button on module cards

### DIFF
--- a/config/routes/modules_catalog.yml
+++ b/config/routes/modules_catalog.yml
@@ -20,6 +20,14 @@ admin_mbo_catalog_module_refresh:
   defaults:
     category:
     keyword:
-    _controller: mbo.controller.modules.catalog::refreshAction
+    _controller: mbo.controller.modules.catalog:refreshAction
     _legacy_controller: AdminPsMboModule
     _legacy_link: AdminPsMboModule:refresh
+
+admin_mbo_module_see_more:
+  path: /see_more/{moduleId}
+  methods: [ GET ]
+  defaults:
+    _controller: mbo.controller.modules.catalog:seeMoreAction
+  requirements:
+    moduleId: \d+

--- a/src/Controller/Admin/ModuleCatalogController.php
+++ b/src/Controller/Admin/ModuleCatalogController.php
@@ -25,6 +25,7 @@ use Exception;
 use PrestaShop\Module\Mbo\Modules\Collection;
 use PrestaShop\Module\Mbo\Modules\Filters;
 use PrestaShop\Module\Mbo\Modules\Repository;
+use PrestaShop\PrestaShop\Core\Addon\AddonsCollection;
 use PrestaShopBundle\Controller\Admin\Improve\Modules\ModuleAbstractController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Service\DataProvider\Admin\CategoriesProvider;
@@ -119,6 +120,35 @@ class ModuleCatalogController extends ModuleAbstractController
         }
 
         return new JsonResponse($responseArray);
+    }
+
+    /**
+     * Responsible of displaying the data inside the modal when user clicks on "See more" on module card
+     *
+     * @param int $moduleId
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function seeMoreAction(int $moduleId): Response
+    {
+        $moduleRepository = $this->get('mbo.modules.repository');
+        $module = $moduleRepository->getModuleById($moduleId);
+
+        $addOnsAdminDataProvider = $this->get('prestashop.core.admin.data_provider.module_interface');
+        $addOnsAdminDataProvider->generateAddonsUrls(
+            AddonsCollection::createFrom([$module])
+        );
+
+        $modulePresenter = $this->get('prestashop.adapter.presenter.module');
+        $moduleToPresent = $modulePresenter->present($module);
+
+        return $this->render(
+            '@PrestaShop/Admin/Module/Includes/modal_read_more_content.html.twig',
+            [
+                'module' => $moduleToPresent,
+                'level' => $this->authorizationLevel(self::CONTROLLER_NAME),
+            ]
+        );
     }
 
     /**

--- a/src/Controller/Admin/ModuleCatalogController.php
+++ b/src/Controller/Admin/ModuleCatalogController.php
@@ -25,7 +25,6 @@ use Exception;
 use PrestaShop\Module\Mbo\Modules\Collection;
 use PrestaShop\Module\Mbo\Modules\Filters;
 use PrestaShop\Module\Mbo\Modules\Repository;
-use PrestaShop\PrestaShop\Core\Addon\AddonsCollection;
 use PrestaShopBundle\Controller\Admin\Improve\Modules\ModuleAbstractController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Service\DataProvider\Admin\CategoriesProvider;
@@ -134,16 +133,14 @@ class ModuleCatalogController extends ModuleAbstractController
         $moduleRepository = $this->get('mbo.modules.repository');
         $module = $moduleRepository->getModuleById($moduleId);
 
-        $addOnsAdminDataProvider = $this->get('prestashop.core.admin.data_provider.module_interface');
-        $addOnsAdminDataProvider->generateAddonsUrls(
-            AddonsCollection::createFrom([$module])
-        );
+        $moduleBuilder = $this->get('mbo.modules.builder');
+        $moduleBuilder->generateAddonsUrls($module);
 
         $modulePresenter = $this->get('prestashop.adapter.presenter.module');
         $moduleToPresent = $modulePresenter->present($module);
 
         return $this->render(
-            '@PrestaShop/Admin/Module/Includes/modal_read_more_content.html.twig',
+            '@Modules/ps_mbo/views/templates/admin/controllers/module_catalog/modal-read-more-content.html.twig',
             [
                 'module' => $moduleToPresent,
                 'level' => $this->authorizationLevel(self::CONTROLLER_NAME),

--- a/src/Modules/ModuleBuilder.php
+++ b/src/Modules/ModuleBuilder.php
@@ -226,6 +226,7 @@ class ModuleBuilder implements ModuleBuilderInterface
         }
 
         $module->attributes->set('urls', $urls);
+        $module->attributes->set('actionTranslationDomains', self::ACTIONS_TRANSLATION_DOMAINS);
 
         if ($urlActive === 'buy' || array_key_exists($urlActive, $urls)) {
             $module->attributes->set('url_active', $urlActive);

--- a/src/Modules/Repository.php
+++ b/src/Modules/Repository.php
@@ -55,7 +55,7 @@ class Repository implements RepositoryInterface
     /**
      * Contains data from cache file about modules on disk.
      *
-     * @var ?array<int, Module>
+     * @var ?array<int|string, Module>
      */
     protected $cache;
 
@@ -182,6 +182,38 @@ class Repository implements RepositoryInterface
         $this->fetchAll();
 
         return $this->cache[$name] ?? null;
+    }
+
+    /**
+     * @param int $moduleId
+     *
+     * @return array
+     */
+    public function getModuleAttributesById(int $moduleId): array
+    {
+        return (array) $this->dataProvider->request('module', ['id_module' => $moduleId]);
+    }
+
+    /**
+     * Send request to get module details on the marketplace, then merge the data received in Module instance.
+     *
+     * @param int $moduleId
+     *
+     * @return Module
+     */
+    public function getModuleById(int $moduleId): ?Module
+    {
+        $moduleAttributes = $this->getModuleAttributesById($moduleId);
+
+        $module = $this->getModule($moduleAttributes['name']);
+
+        foreach ($moduleAttributes as $name => $value) {
+            if (!$module->attributes->has($name)) {
+                $module->attributes->set($name, $value);
+            }
+        }
+
+        return $module;
     }
 
     protected function findInDatabaseByName(string $name): ?array

--- a/src/Traits/Hooks/UseAdminControllerSetMedia.php
+++ b/src/Traits/Hooks/UseAdminControllerSetMedia.php
@@ -22,9 +22,23 @@ declare(strict_types=1);
 namespace PrestaShop\Module\Mbo\Traits\Hooks;
 
 use Exception;
+use Tools;
 
 trait UseAdminControllerSetMedia
 {
+    /**
+     * @return void
+     *
+     * @throws \Exception
+     */
+    public function bootUseAdminControllerSetMedia(): void
+    {
+        if (Tools::getValue('controller') === 'AdminPsMboModule') {
+            $this->context->controller->addJs($this->getPathUri() . 'views/js/catalog-see-more.js?v=' . $this->version);
+            $this->context->controller->addCSS($this->getPathUri() . 'views/css/module-catalog.css?v=' . $this->version);
+        }
+    }
+
     /**
      * Hook actionAdminControllerSetMedia.
      */

--- a/views/css/module-catalog.css
+++ b/views/css/module-catalog.css
@@ -1,0 +1,25 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+.module-read-more-grid {
+  display: inline-block;
+}
+.module-read-more-grid .module-read-more-grid-btn {
+  font-weight: 700;
+}

--- a/views/js/catalog-see-more.js
+++ b/views/js/catalog-see-more.js
@@ -23,7 +23,7 @@
   function registerMboSeeMoreBtnEventHandler() {
     $('body').on(
       'click',
-      'a.module-read-more-grid-btn',
+      'a.module-read-more-grid-btn, a.module-read-more-list-btn',
       (event) => {
         event.preventDefault();
         const modulePoppin = $(event.target).data('target');

--- a/views/js/catalog-see-more.js
+++ b/views/js/catalog-see-more.js
@@ -1,0 +1,42 @@
+'use strict';
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+(function() {
+  function registerMboSeeMoreBtnEventHandler() {
+    $('body').on(
+      'click',
+      'a.module-read-more-grid-btn',
+      (event) => {
+        event.preventDefault();
+        const modulePoppin = $(event.target).data('target');
+
+        $.get(event.target.href, (data) => {
+          $(modulePoppin).html(data);
+          $(modulePoppin).modal();
+        });
+      },
+    );
+  }
+
+  $(document).on('ready', function() {
+    registerMboSeeMoreBtnEventHandler();
+  })
+})();

--- a/views/templates/admin/controllers/module_catalog/includes/card_grid.html.twig
+++ b/views/templates/admin/controllers/module_catalog/includes/card_grid.html.twig
@@ -74,7 +74,7 @@
         </div>
         <div class="module-read-more-grid">
           {% if module.attributes.id != "0" %}
-{#            <a class="module-read-more-grid-btn url" href="{{ path('admin_module_cart', {"moduleId": module.attributes.id }) }}" data-target="#module-modal-read-more-{{module.attributes.name }}{{ additionalModalSuffix|default('') }}">{{ 'Read More'|trans({}, 'Admin.Modules.Feature') }}</a>#}
+            <a class="module-read-more-grid-btn url" href="{{ path('admin_mbo_module_see_more', {"moduleId": module.attributes.id }) }}" data-target="#module-modal-read-more-{{module.attributes.name }}{{ additionalModalSuffix|default('') }}">{{ 'Read More'|trans({}, 'Admin.Modules.Feature') }}</a>
           {% endif %}
         </div>
       {% endblock %}

--- a/views/templates/admin/controllers/module_catalog/includes/card_list.html.twig
+++ b/views/templates/admin/controllers/module_catalog/includes/card_list.html.twig
@@ -82,7 +82,7 @@
             {% endif %}
             <span>
               {% if module.attributes.id != "0" %}
-{#                <a class="module-read-more-list-btn url" href="{{ path('admin_module_cart', {"moduleId": module.attributes.id }) }}" data-target="#module-modal-read-more-{{module.attributes.name }}{{ additionalModalSuffix|default('') }}">{{ 'Read More'|trans({}, 'Admin.Modules.Feature') }}</a>#}
+                <a class="module-read-more-list-btn url" href="{{ path('admin_mbo_module_see_more', {"moduleId": module.attributes.id }) }}" data-target="#module-modal-read-more-{{module.attributes.name }}{{ additionalModalSuffix|default('') }}">{{ 'Read More'|trans({}, 'Admin.Modules.Feature') }}</a>
               {% endif %}
             </span>
           {% endblock %}

--- a/views/templates/admin/controllers/module_catalog/modal-read-more-content.html.twig
+++ b/views/templates/admin/controllers/module_catalog/modal-read-more-content.html.twig
@@ -1,0 +1,229 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+{% set ats = module.attributes %}
+{% set name, displayName, nbRates,
+  starsRate, img, serviceUrl, version, cover, additionalDescription,
+  fullDescription, changeLog, customerBenefits, demoVideo, author, notFoundImg, features, badges =
+  ats.name, ats.displayName, ats.nbRates, ats.starsRate, ats.img,
+  ats.serviceUrl is defined and ats.serviceUrl|length > 0 ? ats.serviceUrl : false,
+  ats.version, ats.cover,
+  ats.additionalDescription is defined and ats.additionalDescription|length > 0 ? ats.additionalDescription : false,
+  ats.fullDescription is defined and ats.fullDescription|length > 0 ? ats.fullDescription : false,
+  ats.changeLog is defined and ats.changeLog|length > 0 ? ats.changeLog : false,
+  ats.customer_benefits is defined and ats.customer_benefits|length > 0 ? ats.customer_benefits : false,
+  ats.demo_video is defined and ats.demo_video|length > 0 ? ats.demo_video : false,
+  ats.author, 'https://cdn4.iconfinder.com/data/icons/ballicons-2-free/100/box-512.png',
+  ats.features,
+  ats.badges is defined and ats.badges|length > 0 ? ats.badges : false
+%}
+<div
+  class="modal-dialog module-modal-dialog">
+  <!-- Modal content-->
+  <div class="modal-content module-modal-content no-padding">
+    <div class="modal-header module-modal-header">
+      {% if nbRates > 0 %}
+        <div class="read-more-stars module-star-ranking-grid-{{ starsRate }}">
+          (
+          {{ nbRates }}
+          )
+        </div>
+      {% endif %}
+      <div>
+        <img class="module-logo-thumb" height="57" width="57" src="{{ img }}" alt="{{ displayName }}"/>
+        <div class="modal-title module-modal-title">
+          <h1>{{ displayName }}<br>
+            <small class="version small-text">
+              {% if serviceUrl is defined and serviceUrl|length > 0 %}
+                {{ 'Service by %author%'|trans({'%author%' : author}, 'Admin.Modules.Feature') }}
+              {% else %}
+                {{ 'v%version% by %author%'|trans({ '%version%' : version, '%author%' : author }, 'Admin.Modules.Feature') }}
+              {% endif %}
+            </small>
+          </h1>
+
+        </div>
+      </div>
+      <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </div>
+
+    <div class="modal-body module-modal-body">
+      <div class="module-big-cover">
+        <img src="{% if cover.big is defined %}{{ cover.big }}{% else %}{{ notFoundImg }}{% endif %}"/>
+      </div>
+      <div class="module-menu-readmore">
+        <nav
+          class="navbar navbar-light">
+          {# tab list #}
+          <ul class="nav nav-pills">
+            <li class="nav-item">
+              <a class="nav-link module-readmore-tab active" data-toggle="tab" href="#overview-{{ name }}">{{ 'Overview'|trans({}, 'Admin.Modules.Feature') }}</a>
+            </li>
+            {% if additionalDescription %}
+              <li class="nav-item">
+                <a class="nav-link module-readmore-tab" data-toggle="tab" href="#additional-{{ name }}">{{ 'Additional information'|trans({}, 'Admin.Modules.Feature') }}</a>
+              </li>
+            {% endif %}
+            {% if customerBenefits %}
+              <li class="nav-item">
+                <a class="nav-link module-readmore-tab" data-toggle="tab" href="#customer_benefits-{{ name }}">{{ 'Benefits'|trans({}, 'Admin.Modules.Feature') }}</a>
+              </li>
+            {% endif %}
+            {% if features %}
+              <li class="nav-item">
+                <a class="nav-link module-readmore-tab" data-toggle="tab" href="#features-{{ name }}">{{ 'Features'|trans({}, 'Admin.Modules.Feature') }}</a>
+              </li>
+            {% endif %}
+            {% if demoVideo %}
+              <li class="nav-item">
+                <a class="nav-link module-readmore-tab" data-toggle="tab" href="#demo_video-{{ name }}">{{ 'Demo video'|trans({}, 'Admin.Modules.Feature') }}</a>
+              </li>
+            {% endif %}
+            {% if changeLog %}
+              <li class="nav-item">
+                <a class="nav-link module-readmore-tab" data-toggle="tab" href="#changelog-{{ name }}">{{ 'Changelog'|trans({}, 'Admin.Modules.Feature') }}</a>
+              </li>
+            {% endif %}
+            {# end tab list #}
+          </ul>
+        </nav>
+        <div
+          class="tab-content">
+          {# tab content list #}
+          <div id="overview-{{ name }}" class="tab-pane fade in active show">
+            <p class="module-readmore-tab-content">
+              {% if fullDescription %}
+                {{ fullDescription|raw }}
+              {% else %}
+                {{ 'No description found for this module :('|trans({}, 'Admin.Modules.Notification') }}
+              {% endif %}
+            </p>
+            {% if module.attributes.multistoreCompatibility is defined and module.attributes.multistoreCompatibility is not same as(constant('\\Module::MULTISTORE_COMPATIBILITY_UNKNOWN')) %}
+              <div class="module-readmore-multistore-content">
+                <h3>{{ 'Multistore compatibility:'|trans({}, 'Admin.Modules.Feature') }}</h3>
+                {% if module.attributes.multistoreCompatibility is same as(constant('\\Module::MULTISTORE_COMPATIBILITY_YES')) %}
+                  {{ 'This module is compatible with the multistore feature. It can be either:'|trans({}, 'Admin.Modules.Feature') }}
+                  <ul>
+                    <li>{{ 'configured differently from one store to another;'|trans({}, 'Admin.Modules.Feature') }}</li>
+                    <li>{{ 'configured quickly in the same way on all stores thanks to the all shops context or to the group of shops;'|trans({}, 'Admin.Modules.Feature') }}</li>
+                    <li>{{ 'or even activated for one store and deactivated for another.'|trans({}, 'Admin.Modules.Feature') }}</li>
+                  </ul>
+                {% elseif module.attributes.multistoreCompatibility is same as(constant('\\Module::MULTISTORE_COMPATIBILITY_PARTIAL')) %}
+                  {{ 'This module is partially compatible with the multistore feature. Some of its options might not be available.'|trans({}, 'Admin.Modules.Feature') }}
+                {% elseif module.attributes.multistoreCompatibility is same as(constant('\\Module::MULTISTORE_COMPATIBILITY_NOT_CONCERNED')) %}
+                  {{ 'This module is not compatible with the multistore feature because it would not be useful.'|trans({}, 'Admin.Modules.Feature') }}
+                {% elseif module.attributes.multistoreCompatibility is same as(constant('\\Module::MULTISTORE_COMPATIBILITY_NO')) %}
+                  {{ 'This module is not compatible with the multistore feature. It means that its configuration applies to all stores.'|trans({}, 'Admin.Modules.Feature') }}
+                {% endif %}
+              </div>
+            {% endif %}
+          </div>
+
+          <div id="additional-{{ name }}" class="tab-pane fade">
+            <p class="module-readmore-tab-content">
+              {% if additionalDescription %}
+                {{ additionalDescription|raw }}
+              {% else %}
+                {{ 'No additional description provided for this module :('|trans({}, 'Admin.Modules.Notification') }}
+              {% endif %}
+            </p>
+          </div>
+
+          <div id="features-{{ name }}" class="tab-pane fade">
+            <p class="module-readmore-tab-content">
+              {% if features %}
+                {{ features|raw }}
+              {% else %}
+                {{ 'No feature list provided for this module :('|trans({}, 'Admin.Modules.Notification') }}
+              {% endif %}
+            </p>
+          </div>
+
+          <div id="customer_benefits-{{ name }}" class="tab-pane fade">
+            <p class="module-readmore-tab-content">
+              {% if customerBenefits %}
+                {{ customerBenefits|raw }}
+              {% else %}
+                {{ 'No customer benefits notes found for this module :('|trans({}, 'Admin.Modules.Notification') }}
+              {% endif %}
+            </p>
+          </div>
+
+          <div id="demo_video-{{ name }}" class="tab-pane fade">
+            <p class="module-readmore-tab-content">
+              {% if demoVideo %}
+                {{ youtube_link(demoVideo)|raw }}
+              {% else %}
+                {{ 'No demonstration video found for this module :('|trans({}, 'Admin.Modules.Notification') }}
+              {% endif %}
+            </p>
+          </div>
+
+          <div id="changelog-{{ name }}" class="tab-pane fade">
+            {% if changeLog %}
+              <ul class="module-readmore-tab-content">
+                {% for version, lines in changeLog|arrayCast|reverse %}
+                  <li>
+                    <b>{{version}}:</b>
+                    {% for line in lines %}
+                      {{line}}<br/>
+                    {% endfor %}
+                  </li>
+                {% endfor %}
+              </ul>
+            {% else %}
+              {{ 'No changelog provided for this module :('|trans({}, 'Admin.Modules.Notification') }}
+            {% endif %}
+          </div>
+          {# end tab content list #}
+        </div>
+      </div>
+    </div>
+
+    <div class="modal-footer module-modal-footer">
+      <div class="module-stars-price">
+        <div class="module-price text-sm-right">
+          {% if module.attributes.url_active == 'buy' and module.attributes.price.raw != '0.00' %}
+            {{ module.attributes.price.displayPrice }}
+          {% elseif module.attributes.url_active != 'buy' %}
+            {{ 'Free'|trans({}, 'Admin.Modules.Feature') }}
+          {% endif %}
+        </div>
+      </div>
+      <div class="module-badges-action">
+        <div class="float-left module-badges-display">
+          {% for badge in badges %}
+            <img src="{{badge.img}}" alt="{{badge.label}}"/>
+            {{badge.label}}
+          {% endfor %}
+        </div>
+        <div class="float-right module-action">
+          {% include '@PrestaShop/Admin/Module/Includes/action_menu.html.twig' with { 'module': module, 'level' : level } %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the MBO project! 
Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 3.x
| Description?      | Get the "See more" logic button from the core to the `ps_mbo` module.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | [#MBO-52](https://forge.prestashop.com/browse/MBO-52)
| How to test?      | Go to the module catalog page. Click on "See more" link in module card. A modal should load (wait a second or 2)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->