### PR TITLE
[MBO-51] Clear catalog cache when user authenticate or logout. Inject services for controllers

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -23,6 +23,14 @@ services:
 
   mbo.controller.modules.catalog:
     class: 'PrestaShop\Module\Mbo\Controller\Admin\ModuleCatalogController'
+    arguments:
+      - '@mbo.addon.toolbar'
+      - '@mbo.modules.filters.factory'
+      - '@mbo.modules.collection.factory'
+      - '@mbo.modules.builder'
+      - '@mbo.modules.repository'
+      - '@prestashop.categories_provider'
+      - '@prestashop.adapter.presenter.module'
 
   mbo.controller.modules.selection:
     class: 'PrestaShop\Module\Mbo\Controller\Admin\ModuleSelectionController'
@@ -52,6 +60,8 @@ services:
       - '@mbo.addon.module.data_provider.addons'
       - '@prestashop.core.admin.data_provider.module_interface'
       - '@prestashop.module.manager'
+      - '@mbo.modules.repository'
+      - '@prestashop.core.admin.module.repository'
 
   mbo.controller.dashboard.news:
     class: 'PrestaShop\Module\Mbo\Controller\Admin\DashboardNewsController'

--- a/src/Addons/User/CookieAddonsUser.php
+++ b/src/Addons/User/CookieAddonsUser.php
@@ -84,8 +84,8 @@ class CookieAddonsUser implements AddonsUserInterface
     public function getAddonsCredentials(): array
     {
         return [
-            'username_addons' => $this->getAndDecrypt('username_addons'),
-            'password_addons' => $this->getAndDecrypt('password_addons'),
+            'username' => $this->getAndDecrypt('username_addons'),
+            'password' => $this->getAndDecrypt('password_addons'),
         ];
     }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 3.x
| Description?      | When a user logs in or logs out, the modules catalog cache is cleaned because results are dependent to the connected user. We also inject services to controllers instead of using the container inside the controllers themselves
| Type?             | improvement
| BC breaks?        | yes
| Deprecations?     | no
| Fixes | [#MBO-51](https://forge.prestashop.com/browse/MBO-51)
| How to test?      | -

