### PR TITLE
[MBO-102] Load subscriber service only if module is enabled 

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -1,5 +1,6 @@
 imports:
     - { resource: services/*.yml }
+    - { resource: services/addons.php }
 
 services:
   _defaults:

--- a/config/services/addons.php
+++ b/config/services/addons.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+declare(strict_types=1);
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use PrestaShop\Module\Mbo\Addons\Subscriber\ModuleManagementEventSubscriber;
+use ps_mbo;
+
+return static function (ContainerConfigurator $container) {
+    $services = $container->services();
+
+    //Only load event subscriber when module is enabled to avoid logging events if disabled
+    if (ps_mbo::checkModuleStatus()) {
+        $services->set('mbo.addons.event_subscriber', ModuleManagementEventSubscriber::class)
+        ->args([ref('logger')])
+        ->public()
+        ->tag('kernel.event_subscriber');
+    }
+};

--- a/config/services/addons.yml
+++ b/config/services/addons.yml
@@ -51,11 +51,3 @@ services:
 
   mbo.addons.week_advice_provider:
     class: PrestaShop\Module\Mbo\Addons\Provider\WeekAdviceProvider
-
-  # Event subscribers
-  mbo.addons.event_subscriber:
-    class: PrestaShop\Module\Mbo\Addons\Subscriber\ModuleManagementEventSubscriber
-    arguments:
-      - '@logger'
-    tags:
-      - { name: 'kernel.event_subscriber', event: 'module.install' }

--- a/ps_mbo.php
+++ b/ps_mbo.php
@@ -207,4 +207,22 @@ class ps_mbo extends Module
 
         return $traits;
     }
+
+    /**
+     * Used to correctly check if the module is enabled or not whe registering services
+     *
+     * @return bool
+     */
+    public static function checkModuleStatus(): bool
+    {
+        $result = Db::getInstance()->getRow('SELECT m.`id_module` as `active`, ms.`id_module` as `shop_active`
+        FROM `' . _DB_PREFIX_ . 'module` m
+        LEFT JOIN `' . _DB_PREFIX_ . 'module_shop` ms ON m.`id_module` = ms.`id_module`
+        WHERE `name` = "ps_mbo"');
+        if ($result) {
+            return $result['active'] && $result['shop_active'];
+        } else {
+            return false;
+        }
+    }
 }

--- a/src/Addons/Subscriber/ModuleManagementEventSubscriber.php
+++ b/src/Addons/Subscriber/ModuleManagementEventSubscriber.php
@@ -33,7 +33,7 @@ class ModuleManagementEventSubscriber implements EventSubscriberInterface
     /**
      * @var LoggerInterface
      */
-    private $logger;
+    protected $logger;
 
     public function __construct(LoggerInterface $logger)
     {
@@ -102,7 +102,7 @@ class ModuleManagementEventSubscriber implements EventSubscriberInterface
         $this->logEvent(ModuleManagementEvent::RESET);
     }
 
-    private function logEvent(string $eventName)
+    protected function logEvent(string $eventName): void
     {
         $this->logger->info(sprintf('Event %s triggered', $eventName));
     }


### PR DESCRIPTION
To prevent logging events when module is not enabled, we need to register the service only when the module is truly enabled.


Is blocked by : [#27969](https://github.com/PrestaShop/PrestaShop/pull/27969)