### PR TITLE
[MBO-150] Add the Official badge on the correct module parameter

### DIFF
--- a/views/templates/admin/controllers/module_catalog/includes/tab-module-line.html.twig
+++ b/views/templates/admin/controllers/module_catalog/includes/tab-module-line.html.twig
@@ -39,7 +39,7 @@
           - <span class="module-badge-bought help-tooltip text-warning" data-title="{{ 'You bought this module on PrestaShop Addons. Thank You.'|trans({}, 'Modules.Mbo.Modulescatalog') }}"><i class="icon-pushpin"></i> <small>{{ 'Bought'|trans({}, 'Modules.Mbo.Modulescatalog') }}</small></span>
         {% elseif module.attributes.type is not empty and module.attributes.type == 'addonsMustHave' %}
           - <span class="module-badge-popular help-tooltip text-primary" data-title="{{ 'This module is available on PrestaShop Addons.'|trans({}, 'Modules.Mbo.Modulescatalog') }}"><i class="icon-group"></i> <small>{{ 'Popular'|trans({}, 'Modules.Mbo.Modulescatalog') }}</small></span>
-        {% elseif module.attributes.type is not empty and module.attributes.type == 'addonsPartner' %}
+        {% elseif module.attributes.author is not empty and module.attributes.author == 'PrestaShop Partners' %}
           - <span class="module-badge-partner help-tooltip text-warning" data-title="{{ 'This module is available for free thanks to our partner.'|trans({}, 'Modules.Mbo.Modulescatalog') }}"><i class="icon-pushpin"></i> <small>{{ 'Official'|trans({}, 'Modules.Mbo.Modulescatalog') }}</small></span>
         {% elseif module.attributes.id is defined and module.attributes.id >= 0 %}
           {% if module.attributes.version_addons is defined and module.attributes.version_addons %}


### PR DESCRIPTION
The type was previously set in an obscure method on 1.7.x and override the true actual type.
I decide to switch to this behavior.