### PR TITLE
[MBO-110] FIx the calls of loadJs & loadCSS files

### DIFF
--- a/src/Traits/Hooks/UseAdminControllerSetMedia.php
+++ b/src/Traits/Hooks/UseAdminControllerSetMedia.php
@@ -34,8 +34,8 @@ trait UseAdminControllerSetMedia
     public function bootUseAdminControllerSetMedia(): void
     {
         if (Tools::getValue('controller') === 'AdminPsMboModule') {
-            $this->context->controller->addJs($this->getPathUri() . 'views/js/catalog-see-more.js?v=' . $this->version);
-            $this->context->controller->addCSS($this->getPathUri() . 'views/css/module-catalog.css?v=' . $this->version);
+            $this->context->controller->addJs($this->getPathUri() . 'views/js/catalog-see-more.js') . '?v=' . $this->version;
+            $this->context->controller->addCSS($this->getPathUri() . 'views/css/module-catalog.css') . '?v=' . $this->version;
         }
     }
 

--- a/src/Traits/Hooks/UseAdminModuleExtraToolbarButton.php
+++ b/src/Traits/Hooks/UseAdminModuleExtraToolbarButton.php
@@ -77,6 +77,6 @@ trait UseAdminModuleExtraToolbarButton
      */
     protected function loadMediaModuleExtraToolbarButton(): void
     {
-        $this->context->controller->addJs($this->getPathUri() . 'views/js/addons-connector.js?v=' . $this->version);
+        $this->context->controller->addJs($this->getPathUri() . 'views/js/addons-connector.js') . '?v=' . $this->version;
     }
 }

--- a/src/Traits/Hooks/UseDashboardZoneOne.php
+++ b/src/Traits/Hooks/UseDashboardZoneOne.php
@@ -81,7 +81,7 @@ trait UseDashboardZoneOne
      */
     protected function loadMediaDashboardZoneOne(): void
     {
-        $this->context->controller->addJs($this->getPathUri() . 'views/js/addons-connector.js?v=' . $this->version);
+        $this->context->controller->addJs($this->getPathUri() . 'views/js/addons-connector.js') . '?v=' . $this->version;
     }
 
     public function useDashboardZoneOneExtraOperations()

--- a/src/Traits/Hooks/UseDashboardZoneThree.php
+++ b/src/Traits/Hooks/UseDashboardZoneThree.php
@@ -57,7 +57,7 @@ trait UseDashboardZoneThree
             ]
         );
 
-        return $this->display($this->name, 'dashboard-zone-three.tpl');
+        return $this->display($this->name, 'views/templates/hook/dashboard-zone-three.tpl');
     }
 
     /**
@@ -93,8 +93,8 @@ trait UseDashboardZoneThree
     protected function loadMediaForDashboardColumnThree(): void
     {
         if (Tools::getValue('controller') === 'AdminDashboard') {
-            $this->context->controller->addJs($this->getPathUri() . 'views/js/dashboard-news.js?v=' . $this->version);
-            $this->context->controller->addCSS($this->getPathUri() . 'views/css/dashboard.css?v=' . $this->version);
+            $this->context->controller->addJs($this->getPathUri() . 'views/js/dashboard-news.js') . '?v=' . $this->version;
+            $this->context->controller->addCSS($this->getPathUri() . 'views/css/dashboard.css') . '?v=' . $this->version;
         }
     }
 }

--- a/src/Traits/Hooks/UseDisplayDashboardTop.php
+++ b/src/Traits/Hooks/UseDisplayDashboardTop.php
@@ -191,12 +191,12 @@ trait UseDisplayDashboardTop
     protected function loadMediaForDashboardTop(): void
     {
         // has to be loaded in header to prevent flash of content
-        $this->context->controller->addJs($this->getPathUri() . 'views/js/recommended-modules.js?v=' . $this->version);
+        $this->context->controller->addJs($this->getPathUri() . 'views/js/recommended-modules.js') . '?v=' . $this->version;
 
         if ($this->shouldAttachRecommendedModules(static::$RECOMMENDED_BUTTON_TYPE)
             || $this->shouldAttachRecommendedModules(static::$RECOMMENDED_AFTER_CONTENT_TYPE)
         ) {
-            $this->context->controller->addCSS($this->getPathUri() . 'views/css/recommended-modules.css');
+            $this->context->controller->addCSS($this->getPathUri() . 'views/css/recommended-modules.css') . '?v=' . $this->version;
             $this->context->controller->addJs(
                 rtrim(__PS_BASE_URI__, '/')
                 . str_ireplace(
@@ -204,9 +204,7 @@ trait UseDisplayDashboardTop
                     '',
                     _PS_BO_ALL_THEMES_DIR_
                 )
-                . 'default/js/bundle/module/module_card.js?v='
-                . _PS_VERSION_
-            );
+                . 'default/js/bundle/module/module_card.js') . '?v=' . $this->version;
         }
     }
 }


### PR DESCRIPTION
I extracted the module version from the build of the file URL as it seems not work well with CSS files.
There is a `file_exists` call in the process, and it returns false when called with `filename.css?v=version`