### PR TITLE
Correctly display the Official badge even on installed modules

### DIFF
--- a/src/Addons/ApiClient.php
+++ b/src/Addons/ApiClient.php
@@ -26,8 +26,8 @@ use stdClass;
 
 class ApiClient
 {
-    const HTTP_METHOD_GET = 'GET';
-    const HTTP_METHOD_POST = 'POST';
+    public const HTTP_METHOD_GET = 'GET';
+    public const HTTP_METHOD_POST = 'POST';
 
     /**
      * @var Client
@@ -71,7 +71,7 @@ class ApiClient
         $this->httpClient = $httpClient;
     }
 
-    public function setDefaultParams(string $locale, $isoCode, string $domain, string $shopVersion): void
+    public function setDefaultParams(string $locale, $isoCode, ?string $domain, string $shopVersion): void
     {
         list($isoLang) = explode('-', $locale);
         $this->setQueryParams([

--- a/src/Module/Module.php
+++ b/src/Module/Module.php
@@ -32,6 +32,8 @@ use Symfony\Component\HttpFoundation\ParameterBag;
  */
 class Module implements ModuleInterface
 {
+    public static $OFFICIAL_PARTNER_AUTHOR = 'PrestaShop Partners';
+
     /**
      * @var LegacyModule Module The instance of the legacy module
      */
@@ -102,6 +104,7 @@ class Module implements ModuleInterface
         // Generate addons urls
         'url_active' => null,
         'urls' => [],
+        'is_official_partner' => false,
     ];
 
     /**

--- a/src/Module/ModuleBuilder.php
+++ b/src/Module/ModuleBuilder.php
@@ -121,6 +121,8 @@ class ModuleBuilder implements ModuleBuilderInterface
             'path' => $this->moduleDirectory . $module->name,
         ];
 
+        // Author can be overrided by the legacyModule, so we have to do that here
+        $attributes['is_official_partner'] = $attributes['author'] === Module::$OFFICIAL_PARTNER_AUTHOR;
         if ($this->isModuleMainClassValid($module->name)) {
             $mainClassAttributes = [];
 

--- a/views/templates/admin/controllers/module_catalog/includes/tab-module-line.html.twig
+++ b/views/templates/admin/controllers/module_catalog/includes/tab-module-line.html.twig
@@ -39,7 +39,7 @@
           - <span class="module-badge-bought help-tooltip text-warning" data-title="{{ 'You bought this module on PrestaShop Addons. Thank You.'|trans({}, 'Modules.Mbo.Modulescatalog') }}"><i class="icon-pushpin"></i> <small>{{ 'Bought'|trans({}, 'Modules.Mbo.Modulescatalog') }}</small></span>
         {% elseif module.attributes.type is not empty and module.attributes.type == 'addonsMustHave' %}
           - <span class="module-badge-popular help-tooltip text-primary" data-title="{{ 'This module is available on PrestaShop Addons.'|trans({}, 'Modules.Mbo.Modulescatalog') }}"><i class="icon-group"></i> <small>{{ 'Popular'|trans({}, 'Modules.Mbo.Modulescatalog') }}</small></span>
-        {% elseif module.attributes.author is not empty and module.attributes.author == 'PrestaShop Partners' %}
+        {% elseif module.attributes.is_official_partner is not empty and module.attributes.is_official_partner %}
           - <span class="module-badge-partner help-tooltip text-warning" data-title="{{ 'This module is available for free thanks to our partner.'|trans({}, 'Modules.Mbo.Modulescatalog') }}"><i class="icon-pushpin"></i> <small>{{ 'Official'|trans({}, 'Modules.Mbo.Modulescatalog') }}</small></span>
         {% elseif module.attributes.id is defined and module.attributes.id >= 0 %}
           {% if module.attributes.version_addons is defined and module.attributes.version_addons %}


### PR DESCRIPTION
The diff in `ApiClient.php` is because during the install of prestashop, this attribute seems to be empty (as PS is not fully loaded), and we had an error here.