### PR TITLE
Fix the const redeclaration behavior

### DIFF
--- a/views/templates/admin/controllers/module_catalog/recommended-modules.html.twig
+++ b/views/templates/admin/controllers/module_catalog/recommended-modules.html.twig
@@ -1,4 +1,4 @@
-{#**
+{# **
   * Copyright since 2007 PrestaShop SA and Contributors
   * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
   *
@@ -15,17 +15,17 @@
   * @author    PrestaShop SA and Contributors <contact@prestashop.com>
   * @copyright Since 2007 PrestaShop SA and Contributors
   * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
-  *#}
+  * #}
 
 {% extends app.request.isxmlhttprequest ? '@Modules/ps_mbo/views/templates/admin/layout-ajax.html.twig' : '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-    <script defer>
-        const renderRecommendations = window.mboCdc.renderRecommendations
+  <script defer>
+    if (typeof window.mboRenderRecommendations === 'undefined') {
+      window.mboRenderRecommendations = window.mboCdc.renderRecommendations
+    }
 
-        const context = {{ shop_context|json_encode()|raw }};
-
-        renderRecommendations(context, '#cdc-container')
-    </script>
-    <div id="cdc-container"></div>
+    window.mboRenderRecommendations({{ shop_context|json_encode()|raw }}, '#cdc-container')
+  </script>
+  <div id="cdc-container"></div>
 {% endblock %}


### PR DESCRIPTION
If we re-click the button to open recommendation modal, we have a JS error because we try to redeclare a constant