### PR TITLE
[MBO-255] Correctly display recommendation in Carriers page

### DIFF
--- a/src/Tab/Tab.php
+++ b/src/Tab/Tab.php
@@ -30,12 +30,10 @@ class Tab implements TabInterface
      * @var string class name of the tab
      */
     protected $legacyClassName;
-
     /**
      * @var string class name of the tab
      */
     protected $displayMode;
-
     /**
      * @var RecommendedModuleCollectionInterface recommended modules of the tab
      */
@@ -154,6 +152,7 @@ class Tab implements TabInterface
     public function shouldDisplayAfterContent(): bool
     {
         return $this->hasRecommendedModules()
-            && TabInterface::DISPLAY_MODE_AFTER_CONTENT === $this->getDisplayMode();
+            && (TabInterface::DISPLAY_MODE_AFTER_CONTENT === $this->getDisplayMode()
+                || $this->legacyClassName === 'AdminCarriers');
     }
 }

--- a/src/Traits/Hooks/UseActionAdminControllerSetMedia.php
+++ b/src/Traits/Hooks/UseActionAdminControllerSetMedia.php
@@ -101,7 +101,11 @@ trait UseActionAdminControllerSetMedia
     {
         $controllerName = Tools::getValue('controller');
 
-        if (!in_array($controllerName, static::$TABS_WITH_RECOMMENDED_MODULES_BUTTON)) {
+        if (
+            !in_array($controllerName, static::$TABS_WITH_RECOMMENDED_MODULES_BUTTON)
+            &&
+            !in_array($controllerName, static::$TABS_WITH_RECOMMENDED_MODULES_AFTER_CONTENT)
+        ) {
             return;
         }
 

--- a/src/Traits/Hooks/UseDisplayDashboardTop.php
+++ b/src/Traits/Hooks/UseDisplayDashboardTop.php
@@ -180,7 +180,11 @@ trait UseDisplayDashboardTop
      */
     protected function displayRecommendedModules(string $controllerName): string
     {
-        if (!in_array($controllerName, static::$TABS_WITH_RECOMMENDED_MODULES_BUTTON)) {
+        if (
+            !in_array($controllerName, static::$TABS_WITH_RECOMMENDED_MODULES_BUTTON)
+            &&
+            !in_array($controllerName, static::$TABS_WITH_RECOMMENDED_MODULES_AFTER_CONTENT)
+        ) {
             return '';
         }
 
@@ -220,7 +224,7 @@ trait UseDisplayDashboardTop
      */
     protected function shouldAttachRecommendedModules(string $type): bool
     {
-        $method = 'shouldDisplay' . (new UnicodeString($type))->camel();
+        $method = 'shouldDisplay' . ucfirst((new UnicodeString($type))->camel()->toString());
         if ($type === static::$RECOMMENDED_BUTTON_TYPE) {
             $modules = static::$TABS_WITH_RECOMMENDED_MODULES_BUTTON;
         } elseif ($type === static::$RECOMMENDED_AFTER_CONTENT_TYPE) {


### PR DESCRIPTION
For an unknown reason, `AdminCarriers` has a wrong display type data returned by the WS.