### PR TITLE
[MBO-300] Fix the modal behavior

### DIFF
--- a/views/js/recommended-modules.js
+++ b/views/js/recommended-modules.js
@@ -374,6 +374,11 @@ var mbo = {};
     };
 
     var openModulesList = function() {
+      var cdcContainer = $('#cdc-container')
+      if(cdcContainer.length > 0 && cdcContainer.html().length > 0) {
+        cdcContainer.html('')
+      }
+      $(pageMap.modulesListLoader).show();
       var recommendedModulesRequest = $.ajax({
         type: 'GET',
         dataType: 'json',


### PR DESCRIPTION
Be sure to have empty content if opening again a recommendation modal.
Force the loader to be shown aswell.

The modal content is removed before the modal is open, so there is no flash of content.