### PR TITLE
[MBO-94] Restore dashboard news block class

### DIFF
--- a/views/templates/hook/dashboard-zone-three.tpl
+++ b/views/templates/hook/dashboard-zone-three.tpl
@@ -32,7 +32,7 @@
   renderPrestashopUpdate(dashboardPrestashopUpdateContext, '#cdc-dashboard-ps-update')
 </script>
 
-<section id="cdc-dashboard-news"></section>
+<section id="cdc-dashboard-news" class="dash_news"></section>
 
 <section id="cdc-dashboard-ps-update"></section>
 


### PR DESCRIPTION
When gamification advices are retrieven, they are written after the dashboard news container. The API response for advices come with an expected selector for dashboard news : `dash_news`

This class was removed when transforming the dashboard news to CDC

This PR restores the class previously removed. It will have no effect on the block design but only used as selector