### PR TITLE
[MBO-432] Fix the update action from back office

### DIFF
--- a/src/Module/ActionsManager.php
+++ b/src/Module/ActionsManager.php
@@ -87,7 +87,7 @@ class ActionsManager
      *
      * @return \stdClass|null
      */
-    private function findVersionForUpdate(string $moduleName): ?\stdClass
+    public function findVersionForUpdate(string $moduleName): ?\stdClass
     {
         $db = \Db::getInstance();
         $request = 'SELECT `version` FROM `' . _DB_PREFIX_ . "module` WHERE name='" . $moduleName . "'";

--- a/src/Traits/Hooks/UseActionBeforeUpgradeModule.php
+++ b/src/Traits/Hooks/UseActionBeforeUpgradeModule.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\Module\Mbo\Traits\Hooks;
+
+use PrestaShop\Module\Mbo\Module\ActionsManager;
+use PrestaShop\Module\Mbo\Module\Exception\ModuleUpgradeNotNeededException;
+use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
+
+trait UseActionBeforeUpgradeModule
+{
+    /**
+     * Hook actionBeforeUpgradeModule.
+     *
+     * @param array $params
+     *
+     * @throws \PrestaShop\Module\Mbo\Module\Exception\ModuleNewVersionNotFoundException
+     * @throws \PrestaShop\Module\Mbo\Module\Exception\ModuleUpgradeNotNeededException
+     * @throws \PrestaShop\Module\Mbo\Module\Exception\UnexpectedModuleSourceContentException
+     */
+    public function hookActionBeforeUpgradeModule(array $params): void
+    {
+        if (!$this->needToDownloadModuleZip($params)) {
+            return;
+        }
+        /** @var ModuleDataProvider $moduleDataProvider */
+        $moduleDataProvider = $this->get('prestashop.adapter.data_provider.module');
+
+        if (empty($params['moduleName']) || !$moduleDataProvider->isOnDisk($params['moduleName'])) {
+            return;
+        }
+
+        $moduleName = (string) $params['moduleName'];
+
+        /** @var ActionsManager $moduleActionsManager */
+        $moduleActionsManager = $this->get('mbo.modules.actions_manager');
+
+        $module = $moduleActionsManager->findVersionForUpdate($moduleName);
+        if (null === $module) {
+            throw new ModuleUpgradeNotNeededException(sprintf('Upgrade not needed for module %s', $moduleName));
+        }
+
+        $moduleActionsManager->downloadAndReplaceModuleFiles($module);
+    }
+
+    /**
+     * We proceed the download only if the update is launched by a back office action.
+     *
+     * @param array $params
+     *
+     * @return bool
+     */
+    private function needToDownloadModuleZip(array $params): bool
+    {
+        if (!empty($params['route']) && $params['route'] === 'admin_module_manage_action') {
+            return true;
+        }
+        if (!empty($params['request']) && $params['request']->get('_controller') === 'PrestaShopBundle\Controller\Admin\Improve\ModuleController::moduleAction' && $params['request']->get('action') === 'upgrade') {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Traits/UseHooks.php
+++ b/src/Traits/UseHooks.php
@@ -42,6 +42,7 @@ trait UseHooks
     use \PrestaShop\Module\Mbo\Traits\Hooks\UseActionDispatcherBefore;
     use \PrestaShop\Module\Mbo\Traits\Hooks\UseActionObjectShopUrlUpdateAfter;
     use \PrestaShop\Module\Mbo\Traits\Hooks\UseActionGeneralPageSave;
+    use \PrestaShop\Module\Mbo\Traits\Hooks\UseActionBeforeUpgradeModule;
 
     /**
      * @var array An array of method that can be called to register media in the actionAdminControllerSetMedia hook


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the MBO project! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 4.0.x
| Description?      | Re add the hook to download module.. Check if the action came from back office before downloading the module
| Type?             | bug fix
| Fixed ticket?     | [MBO-432](https://forge.prestashop.com/browse/MBO-432)
| Possible impacts? | Double-check the update from catalog to be sure that the module is not downloaded twice.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
