### PR TITLE
[MBO-447] fix :zap: Stop calling twice the actions on modules

### DIFF
--- a/src/Module/Workflow/TransitionsManager.php
+++ b/src/Module/Workflow/TransitionsManager.php
@@ -303,13 +303,14 @@ class TransitionsManager
     private function reset(TransitionModule $transitionModule, ?array $context = []): bool
     {
         $moduleName = $transitionModule->getName();
-        if ($this->moduleManager->reset($moduleName)) {
-            $module = $this->getModuleInstance($moduleName);
-            if (null === $module) {
-                return false;
-            }
 
-            return $module->onReset();
+        if ($this->moduleManager->reset($moduleName)) {
+            return true;
+        }
+
+        $error = $this->moduleManager->getError($moduleName);
+        if (!empty($error)) {
+            throw new TransitionFailedException($error);
         }
 
         return false;
@@ -326,16 +327,7 @@ class TransitionsManager
     {
         $moduleName = $transitionModule->getName();
 
-        if ($this->moduleManager->upgrade($moduleName)) {
-            $module = $this->getModuleInstance($moduleName);
-            if (null === $module) {
-                return false;
-            }
-
-            return $module->onUpgrade($transitionModule->getVersion());
-        }
-
-        return false;
+        return $this->moduleManager->upgrade($moduleName);
     }
 
     /**
@@ -344,16 +336,8 @@ class TransitionsManager
     private function uninstall(TransitionModule $transitionModule, ?array $context = []): bool
     {
         $moduleName = $transitionModule->getName();
-        if ($this->moduleManager->uninstall($moduleName)) {
-            $module = $this->getModuleInstance($moduleName);
-            if (null === $module) {
-                return false;
-            }
 
-            return $module->onUninstall();
-        }
-
-        return false;
+        return $this->moduleManager->uninstall($moduleName);
     }
 
     /**
@@ -367,18 +351,14 @@ class TransitionsManager
         }
 
         $moduleName = $transitionModule->getName();
-        if ($this->moduleManager->install($moduleName, $source)) {
-            $module = $this->getModuleInstance($moduleName);
-            if (null === $module) {
-                return false;
-            }
 
-            return $module->onInstall();
-        } else {
-            $error = $this->moduleManager->getError($moduleName);
-            if (!empty($error)) {
-                throw new TransitionFailedException($error);
-            }
+        if ($this->moduleManager->install($moduleName, $source)) {
+            return true;
+        }
+
+        $error = $this->moduleManager->getError($moduleName);
+        if (!empty($error)) {
+            throw new TransitionFailedException($error);
         }
 
         return false;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the MBO project! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Currently in the transitionManager it seems that we call twice the method onInstall, onUninstall... Because they are already triggered by the moduleManager. This can be the source of many errors.
| Type?             | bug fix
| How to test?      | Try to install, uninstall, enable... some modules


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
