### PR TITLE
[MBO-470] Reset cache between uninstall and install when resetting MBO module

### DIFF
--- a/ps_mbo.php
+++ b/ps_mbo.php
@@ -30,6 +30,7 @@ if (file_exists($autoloadPath)) {
 use PrestaShop\Module\Mbo\Accounts\Provider\AccountsDataProvider;
 use PrestaShop\Module\Mbo\Addons\Subscriber\ModuleManagementEventSubscriber;
 use PrestaShop\Module\Mbo\Api\Security\AdminAuthenticationProvider;
+use PrestaShop\Module\Mbo\Helpers\Config;
 use PrestaShop\Module\Mbo\Security\PermissionCheckerInterface;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShopBundle\Event\ModuleManagementEvent;
@@ -171,6 +172,9 @@ class ps_mbo extends Module
         foreach (array_keys($this->configurationList) as $name) {
             Configuration::deleteByName($name);
         }
+
+        // This will reset cached configuration values (uuid, mail, ...) to avoid reusing them
+        Config::resetConfigValues();
 
         /** @var \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher */
         $eventDispatcher = $this->get('event_dispatcher');

--- a/src/Helpers/Config.php
+++ b/src/Helpers/Config.php
@@ -39,6 +39,13 @@ class Config
      */
     private static $SHOP_URL;
 
+    public static function resetConfigValues(): void
+    {
+        self::$SHOP_MBO_UUID = null;
+        self::$SHOP_MBO_ADMIN_MAIL = null;
+        self::$SHOP_URL = null;
+    }
+
     public static function getShopMboUuid(): ?string
     {
         if (null === self::$SHOP_MBO_UUID) {

--- a/src/Traits/HaveShopOnExternalService.php
+++ b/src/Traits/HaveShopOnExternalService.php
@@ -70,7 +70,7 @@ trait HaveShopOnExternalService
             /** @var Client $distributionApi */
             $distributionApi = $this->getService('mbo.cdc.client.distribution_api');
             $distributionApi->setBearer($this->getAdminAuthenticationProvider()->getMboJWT());
-            $t = $distributionApi->unregisterShop();
+            $distributionApi->unregisterShop();
         } catch (Exception $e) {
             // Do nothing here, the exception is caught to avoid displaying an error to the client
             // Furthermore, the operation can't be tried again later as the module is now disabled or uninstalled


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the MBO project! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 4.0.x
| Description?      | The MBO config values (UUID, ADMIN_MAIL, ...) are cached. When resetting, we uninstall and install the module but in a same thread. That's why the values used to re-register the shop are wrong. In this PR we reset that static cache anytime the configuration values are deleted
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes MBO-470
| How to test?      | Install MBO, display the modules catalogue. Reset the module and then go back to the modules catalogue. The page must be displayed without error

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
