### PR TITLE
Feat :sparkles: Fix PS8 compatibility by disabling hook execution

### DIFF
--- a/ps_mbo.php
+++ b/ps_mbo.php
@@ -139,14 +139,14 @@ class ps_mbo extends Module
     public function __construct()
     {
         $this->name = 'ps_mbo';
-        $this->version = '2.0.2';
+        $this->version = '2.0.3';
         $this->author = 'PrestaShop';
         $this->tab = 'administration';
         $this->module_key = '6cad5414354fbef755c7df4ef1ab74eb';
         $this->need_instance = 0;
         $this->ps_versions_compliancy = [
             'min' => '1.7.5.0',
-            'max' => _PS_VERSION_,
+            'max' => '8.0.0',
         ];
 
         parent::__construct();
@@ -310,6 +310,13 @@ class ps_mbo extends Module
      */
     public function hookActionAdminControllerSetMedia()
     {
+        if (strpos(_PS_VERSION_, '8') === 0) {
+            if (Tools::getValue('controller') === 'AdminDashboard') {
+                $this->context->controller->addCSS($this->getPathUri() . 'views/css/push-new-version-legacy.css');
+            }
+
+            return;
+        }
         // has to be loaded in header to prevent flash of content
         $this->context->controller->addJs($this->getPathUri() . 'views/js/recommended-modules.js?v=' . $this->version);
 
@@ -338,6 +345,17 @@ class ps_mbo extends Module
      */
     public function hookDisplayDashboardTop()
     {
+        if (strpos(_PS_VERSION_, '8') === 0) {
+            if (Tools::getValue('controller') === 'AdminDashboard') {
+                $this->smarty->assign([
+                    'newVesionUrl' => 'https://prestashop.com/edition',
+                ]);
+
+                return $this->fetch('module:ps_mbo/views/templates/hook/push-new-version-legacy.tpl');
+            }
+
+            return '';
+        }
         /** @var UrlGeneratorInterface $router */
         $router = $this->get('router');
 

--- a/tests/phpstan/phpstan-latest.neon
+++ b/tests/phpstan/phpstan-latest.neon
@@ -6,6 +6,5 @@ parameters:
 	dynamicConstantNames:
 		- _PS_VERSION_
 	ignoreErrors:
-		- '#Parameter \#1 \$idProfile of static method ProfileCore::getProfileAccess\(\) expects int, string given.#'
 
 	level: 5

--- a/views/css/push-new-version-legacy.css
+++ b/views/css/push-new-version-legacy.css
@@ -1,0 +1,26 @@
+/**
+ * 2007-2020 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+#mbo-push-version-container {
+  font-size: 14px;
+}
+#mbo-push-version-container .alert-title {
+  font-weight: bold;
+  font-size: 16px;
+}

--- a/views/templates/hook/push-new-version-legacy.tpl
+++ b/views/templates/hook/push-new-version-legacy.tpl
@@ -1,0 +1,32 @@
+{**
+ * 2007-2020 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *}
+
+<div id="mbo-push-version-container" class="alert alert-danger" role="alert">
+  <span class="alert-title">
+      {l s='A new version of your modules catalogue is available.' d='Modules.Mbo.Dasboard'}
+  </span>
+  <div>
+    <p>
+        {l s='Please proceed to the update in order to ensure the good compatibility of your modules with your version of PrestaShop !' d='Modules.Mbo.Dasboard'}
+    </p>
+    <a class="btn btn-primary" href="{l s='https://addons.prestashop.com/en/administrative-tools/39574-prestashop-marketplace-in-your-back-office.html' d='Modules.Mbo.Dasboard'}" target="_blank">
+        {l s='Download the last version' d='Modules.Mbo.Dasboard'}
+    </a>
+  </div>
+</div>


### PR DESCRIPTION
Adding a message to the dashboard in order to install the new version of MBO

<!-----------------------------------------------------------------------------
Thank you for contributing to the MBO project! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 2.0.x
| Description?      | Fix the PS8 compat. The hooks are not executed anymore, so the module does not break the shop. Add a  panel to the dashboard that link the user to the addons page of the module. Problem [saw here](https://github.com/PrestaShop/PrestaShop/issues/30100)
| Type?             | bug fix / improvement

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
