### PR TITLE
[MBO-509] Fill Shop PS version when querying for Menu config

### DIFF
--- a/src/Distribution/Client.php
+++ b/src/Distribution/Client.php
@@ -204,6 +204,7 @@ class Client
 
         $this->setQueryParams([
             'isoLang' => $languageIsoCode,
+            'shopVersion' => _PS_VERSION_,
         ]);
         try {
             $conf = $this->processRequestAndReturn('shops/conf');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the MBO project! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 4.1.x
| Description?      | Add query param shopVersion when sending query to Nest for retrieving Menu conf
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes MBO-509
| How to test?      | -


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
