### PR TITLE
[MBO-540][MBO-541] Change encryption for addons credentials + handle authentification on API requests

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -62,3 +62,4 @@ services:
       - '@prestashop.module.manager'
       - '@mbo.modules.repository'
       - '@prestashop.core.admin.module.repository'
+      - '@mbo.addons.user.credentials_encryptor'

--- a/config/services/addons.yml
+++ b/config/services/addons.yml
@@ -2,10 +2,16 @@ services:
   _defaults:
     public: true
 
+  mbo.addons.user.credentials_encryptor:
+    class: PrestaShop\Module\Mbo\Addons\User\CredentialsEncryptor
+    arguments:
+      - '@mbo.security.admin_authentication.provider'
+
   mbo.addons.user:
     class: PrestaShop\Module\Mbo\Addons\User\AddonsUser
     arguments:
       - '@session'
+      - '@mbo.addons.user.credentials_encryptor'
 
   mbo.addons.user.provider:
     class: PrestaShop\Module\Mbo\Addons\User\AddonsUserProvider

--- a/src/Addons/Provider/AddonsDataProvider.php
+++ b/src/Addons/Provider/AddonsDataProvider.php
@@ -22,7 +22,6 @@ declare(strict_types=1);
 namespace PrestaShop\Module\Mbo\Addons\Provider;
 
 use Exception;
-use PhpEncryption;
 use PrestaShop\Module\Mbo\Addons\ApiClient;
 use PrestaShop\Module\Mbo\Addons\User\UserInterface;
 
@@ -74,11 +73,6 @@ class AddonsDataProvider implements DataProviderInterface
     protected $marketplaceClient;
 
     /**
-     * @var PhpEncryption
-     */
-    protected $encryption;
-
-    /**
      * @var string the cache directory location
      */
     public $cacheDir;
@@ -104,7 +98,6 @@ class AddonsDataProvider implements DataProviderInterface
         ?string $moduleChannel = null
     ) {
         $this->marketplaceClient = $apiClient;
-        $this->encryption = new PhpEncryption(_NEW_COOKIE_KEY_);
         $this->moduleChannel = $moduleChannel ?? self::ADDONS_API_MODULE_CHANNEL_STABLE;
         $this->user = $user;
     }

--- a/src/Addons/User/AddonsUser.php
+++ b/src/Addons/User/AddonsUser.php
@@ -22,7 +22,7 @@ declare(strict_types=1);
 namespace PrestaShop\Module\Mbo\Addons\User;
 
 use Exception;
-use PhpEncryptionCore as PhpEncryption;
+use PrestaShop\Module\Mbo\Addons\User\CredentialsEncryptor;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
@@ -32,9 +32,9 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 class AddonsUser implements UserInterface
 {
     /**
-     * @var PhpEncryption
+     * @var CredentialsEncryptor
      */
-    private $encryption;
+    protected $encryption;
 
     /**
      * @var Request
@@ -46,9 +46,9 @@ class AddonsUser implements UserInterface
      */
     private $session;
 
-    public function __construct(SessionInterface $session)
+    public function __construct(SessionInterface $session, CredentialsEncryptor $encryption)
     {
-        $this->encryption = new PhpEncryption(_NEW_COOKIE_KEY_);
+        $this->encryption = $encryption;
         $this->request = Request::createFromGlobals();
         $this->session = $session;
     }

--- a/src/Addons/User/CredentialsEncryptor.php
+++ b/src/Addons/User/CredentialsEncryptor.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\Module\Mbo\Addons\User;
+
+use PrestaShop\Module\Mbo\Api\Security\AdminAuthenticationProvider;
+
+class CredentialsEncryptor
+{
+    /**
+     * @var AdminAuthenticationProvider
+     */
+    private $adminAuthenticationProvider;
+    
+    public function __construct(AdminAuthenticationProvider $adminAuthenticationProvider)
+    {
+        $this->adminAuthenticationProvider = $adminAuthenticationProvider;
+    }
+
+    public function encrypt(string $value): string
+    {
+        return base64_encode(sprintf('%s%s', $value, $this->getSalt()));        
+    }
+
+    public function decrypt(string $value): string
+    {        
+        return str_replace($this->getSalt(), '', base64_decode($value));
+    }
+    
+    private function getSalt(): string
+    {
+        return $this->adminAuthenticationProvider->getAdminToken();
+    }
+}

--- a/src/Module/CommandHandler/ModuleStatusTransitionCommandHandler.php
+++ b/src/Module/CommandHandler/ModuleStatusTransitionCommandHandler.php
@@ -90,6 +90,10 @@ final class ModuleStatusTransitionCommandHandler
         } else {
             $apiModule = $this->moduleRepository->getApiModule($moduleName);
 
+            if (null === $apiModule) {
+                throw new ModuleNotFoundException(sprintf('Module %s not found', $moduleName));
+            }
+
             $module = new TransitionModule(
                 $moduleName,
                 $apiModule->version,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the MBO project! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 4.1.x
| Description?      | Change the way to encrypt addons credentials when user authenticates. MBO API can now receive addons credentials and forward them when requesting Addons API. That authentication is only available during the request
| Type?             | new feature
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes MBO-540 / MBO-556 and MBO-541 / MBO-564
| How to test?      | -
| Possible impacts? | -


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
