### PR TITLE
fix(ProductPage): Don't load module_card on Product Page

### DIFF
--- a/ps_mbo.php
+++ b/ps_mbo.php
@@ -317,16 +317,18 @@ class ps_mbo extends Module
             || $this->shouldAttachRecommendedModulesAfterContent()
         ) {
             $this->context->controller->addCSS($this->getPathUri() . 'views/css/recommended-modules.css');
-            $this->context->controller->addJs(
-                rtrim(__PS_BASE_URI__, '/')
-                . str_ireplace(
-                    _PS_CORE_DIR_,
-                    '',
-                    _PS_BO_ALL_THEMES_DIR_
-                )
-                . 'default/js/bundle/module/module_card.js?v='
-                . _PS_VERSION_
-            );
+            if (Tools::getValue('controller') !== 'AdminProducts') {
+                $this->context->controller->addJs(
+                    rtrim(__PS_BASE_URI__, '/')
+                    . str_ireplace(
+                        _PS_CORE_DIR_,
+                        '',
+                        _PS_BO_ALL_THEMES_DIR_
+                    )
+                    . 'default/js/bundle/module/module_card.js?v='
+                    . _PS_VERSION_
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Apparently, the addJS method does not check all JS that will be loaded on the page.
So we still have a duplicate on this one.
Actually, it seems that only the product page is broken.

<!-----------------------------------------------------------------------------
Thank you for contributing to the MBO project! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 2.0.x
| Description?      | Script is already loaded by the core, and create a JS error on the page which cause problems.
| Type?             | bug fix
| Fixed ticket?     | Fixes #109 



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
