### PR TITLE
[MBO-585] MBO reset : Change salt of addons credential and update cookies

### DIFF
--- a/config/services/addons.yml
+++ b/config/services/addons.yml
@@ -46,3 +46,11 @@ services:
       - '@mbo.security.permission_checker'
       - '@mbo.addons.data_provider'
       - '@translator'
+
+  mbo.addons.event_listener.addons_credentials_encryption_listener:
+    class: PrestaShop\Module\Mbo\Addons\Listener\AddonsCredentialsEncryptionListener
+    arguments:
+      - '@session'
+      - '@mbo.addons.user.credentials_encryptor'
+    tags:
+      - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }

--- a/src/Addons/Listener/AddonsCredentialsEncryptionListener.php
+++ b/src/Addons/Listener/AddonsCredentialsEncryptionListener.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\Module\Mbo\Addons\Listener;
+
+use PrestaShop\Module\Mbo\Addons\User\CredentialsEncryptor;
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+
+final class AddonsCredentialsEncryptionListener
+{
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+    /**
+     * @var CredentialsEncryptor
+     */
+    private $encryptor;
+
+    public function __construct(
+        SessionInterface $session,
+        CredentialsEncryptor $encryptor
+    ) {
+        $this->session = $session;
+        $this->encryptor = $encryptor;
+    }
+
+    public function onKernelResponse(ResponseEvent $event)
+    {
+        $response = $event->getResponse();
+
+        if ($this->session->has('credentials_decrypted_before_reset')) {
+            $this->session->remove('credentials_decrypted_before_reset');
+
+            $response->headers->setCookie(
+                new Cookie('username_addons_v2', $this->encryptor->encrypt($this->session->get('username_addons_v2')), -1, null, null, null, false)
+            );
+            $response->headers->setCookie(
+                new Cookie('password_addons_v2', $this->encryptor->encrypt($this->session->get('password_addons_v2')), -1, null, null, null, false)
+            );
+
+            $this->session->remove('username_addons_v2');
+            $this->session->remove('password_addons_v2');
+//            $this->session->save();
+
+            $event->setResponse($response);
+        }
+    }
+}

--- a/src/Addons/Listener/AddonsCredentialsEncryptionListener.php
+++ b/src/Addons/Listener/AddonsCredentialsEncryptionListener.php
@@ -61,7 +61,6 @@ final class AddonsCredentialsEncryptionListener
 
             $this->session->remove('username_addons_v2');
             $this->session->remove('password_addons_v2');
-//            $this->session->save();
 
             $event->setResponse($response);
         }

--- a/src/Addons/User/CredentialsEncryptor.php
+++ b/src/Addons/User/CredentialsEncryptor.php
@@ -29,7 +29,7 @@ class CredentialsEncryptor
      * @var AdminAuthenticationProvider
      */
     private $adminAuthenticationProvider;
-    
+
     public function __construct(AdminAuthenticationProvider $adminAuthenticationProvider)
     {
         $this->adminAuthenticationProvider = $adminAuthenticationProvider;
@@ -37,14 +37,14 @@ class CredentialsEncryptor
 
     public function encrypt(string $value): string
     {
-        return base64_encode(sprintf('%s%s', $value, $this->getSalt()));        
+        return base64_encode(sprintf('%s%s', $value, $this->getSalt()));
     }
 
     public function decrypt(string $value): string
-    {        
+    {
         return str_replace($this->getSalt(), '', base64_decode($value));
     }
-    
+
     private function getSalt(): string
     {
         return $this->adminAuthenticationProvider->getAdminToken();

--- a/src/Traits/Hooks/UseActionBeforeResetModule.php
+++ b/src/Traits/Hooks/UseActionBeforeResetModule.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\Module\Mbo\Traits\Hooks;
+
+use PrestaShop\Module\Mbo\Addons\User\CredentialsEncryptor;
+use PrestaShop\Module\Mbo\Module\Module;
+use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+trait UseActionBeforeResetModule
+{
+    /**
+     * Hook actionBeforeResetModule.
+     */
+    public function hookActionBeforeResetModule(array $params): void
+    {
+        /** @var ModuleDataProvider $moduleDataProvider */
+        $moduleDataProvider = $this->get('prestashop.adapter.data_provider.module');
+
+        if (empty($params['moduleName']) || !$moduleDataProvider->isOnDisk($params['moduleName'])) {
+            return;
+        }
+
+        $moduleName = (string) $params['moduleName'];
+
+        if ('ps_mbo' === $moduleName) {
+            $this->storeAddonsCredentials($params);
+        }
+    }
+
+    private function storeAddonsCredentials(array $params)
+    {
+        if (!empty($params['request']) && $params['request']->get('action') === 'reset') {
+            /**
+             * @var Request $request
+             */
+            $request = $params['request'];
+
+            $addonsUsername = $request->cookies->get('username_addons_v2');
+            $addonsPassword = $request->cookies->get('password_addons_v2');
+
+            if (null !== $addonsUsername && null !== $addonsPassword) {
+                /** @var CredentialsEncryptor $encryptor */
+                $encryptor = $this->get('mbo.addons.user.credentials_encryptor');
+
+                /** @var SessionInterface $session */
+                $session = $this->get('session');
+
+                $session->set('username_addons_v2', $encryptor->decrypt($addonsUsername));
+                $session->set('password_addons_v2', $encryptor->decrypt($addonsPassword));
+
+                $session->set('credentials_decrypted_before_reset', 1);
+            }
+        }
+    }
+}

--- a/src/Traits/UseHooks.php
+++ b/src/Traits/UseHooks.php
@@ -34,6 +34,7 @@ trait UseHooks
     use \PrestaShop\Module\Mbo\Traits\Hooks\UseDisplayDashboardTop;
     use \PrestaShop\Module\Mbo\Traits\Hooks\UseActionAdminControllerSetMedia;
     use \PrestaShop\Module\Mbo\Traits\Hooks\UseActionBeforeInstallModule;
+    use \PrestaShop\Module\Mbo\Traits\Hooks\UseActionBeforeResetModule;
     use \PrestaShop\Module\Mbo\Traits\Hooks\UseActionGetAdminToolbarButtons;
     use \PrestaShop\Module\Mbo\Traits\Hooks\UseActionGetAlternativeSearchPanels;
     use \PrestaShop\Module\Mbo\Traits\Hooks\UseDisplayBackOfficeFooter;

--- a/upgrade/upgrade-4.2.0.php
+++ b/upgrade/upgrade-4.2.0.php
@@ -23,21 +23,9 @@
  *
  * @return bool
  */
-function upgrade_module_4_1_1(Module $module): bool
+function upgrade_module_4_2_0(Module $module): bool
 {
-    $parentTab = Tab::getInstanceFromClassName('AdminPsMboModuleParent');
-    $moduleTab = Tab::getInstanceFromClassName('AdminPsMboModule');
-    $languages = Language::getIDs(false);
-    $tabNameByLangId = array_fill_keys($languages, 'Marketplace');
-
-    if (Validate::isLoadedObject($parentTab)) {
-        $parentTab->name = $tabNameByLangId;
-        $parentTab->save();
-    }
-    if (Validate::isLoadedObject($moduleTab)) {
-        $moduleTab->name = $tabNameByLangId;
-        $moduleTab->save();
-    }
+    $module->updateHooks();
 
     return true;
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the MBO project! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 4.2.x
| Description?      | The addons credentials are salted with the shop adminToken, encrypted and stored as cookies. When a MBO module reset is performed, that adminToken changed so it's becoming impossible to decrypt the cookies. This PR aim to decrypt and store the credentials in session before the reset; after the reset, re-encrypt them and re-store them as cookies; and then clean the values stored in clear
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes MBO-585
| How to test?      | Log in to addons, reset MBO module. You'll remain connected


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
