### PR TITLE
Avoid usage of services upgrade

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
   <name>ps_mbo</name>
   <displayName><![CDATA[PrestaShop Marketplace in your Back Office]]></displayName>
-  <version><![CDATA[4.1.2]]></version>
+  <version><![CDATA[4.1.3]]></version>
   <description><![CDATA[Discover the best PrestaShop modules to optimize your online store.]]></description>
   <author><![CDATA[PrestaShop]]></author>
   <tab><![CDATA[administration]]></tab>

--- a/ps_mbo.php
+++ b/ps_mbo.php
@@ -49,7 +49,7 @@ class ps_mbo extends Module
     /**
      * @var string
      */
-    public const VERSION = '4.1.2';
+    public const VERSION = '4.1.3';
 
     public const CONTROLLERS_WITH_CONNECTION_TOOLBAR = [
         'AdminPsMboModule',
@@ -101,7 +101,7 @@ class ps_mbo extends Module
     public function __construct()
     {
         $this->name = 'ps_mbo';
-        $this->version = '4.1.2';
+        $this->version = '4.1.3';
         $this->author = 'PrestaShop';
         $this->tab = 'administration';
         $this->module_key = '6cad5414354fbef755c7df4ef1ab74eb';

--- a/src/Traits/HaveTabs.php
+++ b/src/Traits/HaveTabs.php
@@ -23,7 +23,6 @@ namespace PrestaShop\Module\Mbo\Traits;
 
 use Db;
 use LanguageCore as Language;
-use PrestaShopBundle\Entity\Repository\TabRepository;
 use Symfony\Component\String\UnicodeString;
 use TabCore as Tab;
 use ValidateCore as Validate;
@@ -82,11 +81,6 @@ trait HaveTabs
     ];
 
     /**
-     * @var TabRepository
-     */
-    protected $tabRepository;
-
-    /**
      * Apply given method on all Tabs
      * Values can be 'install' or 'uninstall'
      *
@@ -102,9 +96,7 @@ trait HaveTabs
         if (!method_exists($this, $methodName)) {
             return false;
         }
-        /** @var TabRepository $tabRepository */
-        $tabRepository = $this->get('prestashop.core.admin.tab.repository');
-        $this->tabRepository = $tabRepository;
+
         foreach (static::$ADMIN_CONTROLLERS as $tabData) {
             if (false === $this->{$methodName}($tabData)) {
                 return false;
@@ -130,7 +122,7 @@ trait HaveTabs
             $tabData['name']
         );
 
-        $idParent = empty($tabData['parent_class_name']) ? -1 : $this->tabRepository->findOneIdByClassName($tabData['parent_class_name']);
+        $idParent = empty($tabData['parent_class_name']) ? -1 : $tabId = Tab::getIdFromClassName($tabData['parent_class_name']);
 
         $tab = new Tab();
         $tab->module = $this->name;
@@ -168,7 +160,7 @@ trait HaveTabs
      */
     public function uninstallTab(array $tabData): bool
     {
-        $tabId = $this->tabRepository->findOneIdByClassName($tabData['class_name']);
+        $tabId = Tab::getIdFromClassName($tabData['class_name']);
         $tab = new Tab($tabId);
 
         if (false === Validate::isLoadedObject($tab)) {
@@ -217,9 +209,6 @@ trait HaveTabs
                 $newTabs[] = $tab;
             }
         }
-
-        $tabRepository = $this->get('prestashop.core.admin.tab.repository');
-        $this->tabRepository = $tabRepository;
 
         foreach ($oldTabs as $oldTab) {
             $this->uninstallTab(['class_name' => $oldTab]);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the MBO project! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 4.1.x
| Description?      | On upgrade script to 4.1.0, we are using $module->updateTabs which uses the TabRepository service. During autoupgrade, service container is unavailable. That makes that usage impossible. We are now using Tab::getIdFromClassName which is not using  service container
| Type?             | bug fix
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | -
| How to test?      | Test MBO upgrade and PS autoupgrade


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
