### PR TITLE
Change cdc url on cdn for prod & preprod

### DIFF
--- a/src/Traits/HaveConfigurationPage.php
+++ b/src/Traits/HaveConfigurationPage.php
@@ -22,12 +22,12 @@ trait HaveConfigurationPage
             'addons' => 'https://preprod-api-addons.prestashop.com',
         ],
         'preprod' => [
-            'cdc' => 'https://preproduction-assets.prestashop3.com/dst/mbo/latest/mbo-cdc.umd.js',
+            'cdc' => 'https://preproduction-assets.prestashop3.com/dst/mbo/v1/mbo-cdc.umd.js',
             'api' => 'https://mbo-api-preprod.prestashop.com',
             'addons' => 'https://preprod-api-addons.prestashop.com',
         ],
         'prod' => [
-            'cdc' => 'https://assets.prestashop3.com/dst/mbo/latest/mbo-cdc.umd.js',
+            'cdc' => 'https://assets.prestashop3.com/dst/mbo/v1/mbo-cdc.umd.js',
             'api' => 'https://mbo-api.prestashop.com',
             'addons' => 'https://api-addons.prestashop.com',
         ],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the MBO project! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 4.2.x
| Description?      | Following changes in the google cloud config, do not use the `latest/` sub-folder to retrieve the source code of the cdc but the `v1/` sub-folder. `latest/` is destined to disappear
| Type?             | fix on preprod deployement


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
