### PR TITLE
[MBO-620] Do not remove addons connection on all modules uninstall

### DIFF
--- a/src/Addons/Listener/AddonsCredentialsEncryptionListener.php
+++ b/src/Addons/Listener/AddonsCredentialsEncryptionListener.php
@@ -51,6 +51,14 @@ final class AddonsCredentialsEncryptionListener
         $response = $event->getResponse();
         $request = $event->getRequest();
 
+        // There must be an action on MBO module to perform something on this listener
+        if (
+            $request->get('_controller') !== 'PrestaShopBundle\Controller\Admin\Improve\ModuleController::moduleAction'
+            || 'ps_mbo' !== $request->get('module_name')
+        ) {
+            return;
+        }
+
         // If the module is being uninstalled, we remove the addons credentials from the cookies
         if ('uninstall' === $request->get('action')) {
             $response = $this->clearAddonsCookiesFromResponse($response);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the MBO project! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 4.2.x
| Description?      | Check that action is made on MBO module before doing process on addons cookies
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes MBO-620
| How to test?      | Install MBO, connect to addons, uninstall any other module than MBO, see that addons connection is kept

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
