### PR TITLE
Do not transmit Accounts token in context

### DIFF
--- a/src/Service/View/ContextBuilder.php
+++ b/src/Service/View/ContextBuilder.php
@@ -170,7 +170,7 @@ class ContextBuilder
             'installed_modules' => $this->getInstalledModules(),
             'accounts_user_id' => $this->accountsDataProvider->getAccountsUserId(),
             'accounts_shop_id' => $this->accountsDataProvider->getAccountsShopId(),
-            'accounts_token' => $this->accountsDataProvider->getAccountsToken(),
+            'accounts_token' => '',
         ];
     }
 


### PR DESCRIPTION
Do not transmit Accounts JWT to context to always use addons credentials. This is done to finish this feature properly