### PR TITLE
[MBO-504] Use Accounts token to request Addons API

### DIFF
--- a/src/Addons/ApiClient.php
+++ b/src/Addons/ApiClient.php
@@ -40,6 +40,8 @@ class ApiClient
      */
     protected $queryParameters = ['format' => 'json'];
 
+    protected $headers = [];
+
     /**
      * @var array<string, string>
      */
@@ -90,6 +92,7 @@ class ApiClient
     public function reset(): void
     {
         $this->queryParameters = $this->defaultQueryParameters;
+        $this->headers = [];
     }
 
     /**
@@ -98,6 +101,11 @@ class ApiClient
     public function getQueryParameters(): array
     {
         return $this->queryParameters;
+    }
+
+    public function getHeaders(): array
+    {
+        return $this->headers;
     }
 
     /**
@@ -284,8 +292,15 @@ class ApiClient
      */
     public function processRequest(string $method = self::HTTP_METHOD_GET): string
     {
+        $options = ['query' => $this->queryParameters];
+
+        $headers = $this->getHeaders();
+        if (!empty($headers)) {
+            $options['headers'] = $headers;
+        }
+
         return (string) $this->httpClient
-            ->request($method, '', ['query' => $this->queryParameters])
+            ->request($method, '', $options)
             ->getBody();
     }
 
@@ -310,6 +325,13 @@ class ApiClient
     {
         $filteredParams = array_intersect_key($params, array_flip($this->possibleQueryParameters));
         $this->queryParameters = array_merge($this->queryParameters, $filteredParams);
+
+        return $this;
+    }
+
+    public function setHeaders(array $headers): self
+    {
+        $this->headers = array_merge($this->headers, $headers);
 
         return $this;
     }

--- a/src/Addons/Provider/AddonsDataProvider.php
+++ b/src/Addons/Provider/AddonsDataProvider.php
@@ -171,9 +171,18 @@ class AddonsDataProvider implements DataProviderInterface
             throw new Exception("Action '{$action}' not found in actions list.");
         }
 
+        $this->marketplaceClient->reset();
+
         // We merge the addons credentials
         if ($this->isUserAuthenticated()) {
-            $params = array_merge($this->user->getCredentials(), $params);
+            $credentials = $this->user->getCredentials();
+            if (array_key_exists('accounts_token', $credentials)) {
+                $this->marketplaceClient->setHeaders([
+                    'Authorization' => 'Bearer ' . $credentials['accounts_token'],
+                ]);
+            } else {
+                $params = array_merge($credentials, $params);
+            }
         }
 
         if ($action === 'module_download') {
@@ -181,8 +190,6 @@ class AddonsDataProvider implements DataProviderInterface
         } elseif ($action === 'native_all') {
             $params['iso_code'] = 'all';
         }
-
-        $this->marketplaceClient->reset();
 
         try {
             return $this->marketplaceClient->{self::ADDONS_API_MODULE_ACTIONS[$action]}($params);

--- a/src/Addons/User/AddonsUser.php
+++ b/src/Addons/User/AddonsUser.php
@@ -57,7 +57,7 @@ class AddonsUser implements UserInterface
      */
     public function isAuthenticated(): bool
     {
-        return $this->hasCookieAuthenticated() || $this->hasSessionAuthenticated();
+        return $this->hasAccountsTokenInSession() || $this->hasCookieAuthenticated() || $this->hasSessionAuthenticated();
     }
 
     /**
@@ -65,6 +65,12 @@ class AddonsUser implements UserInterface
      */
     public function getCredentials(bool $encrypted = false): array
     {
+        $accountsToken = $this->getFromSession('accounts_token');
+
+        if (null !== $accountsToken) {
+            return ['accounts_token' => $accountsToken];
+        }
+
         return $encrypted ?
             [
                 'username' => $this->get('username_addons_v2'),
@@ -156,5 +162,10 @@ class AddonsUser implements UserInterface
     {
         return $this->getFromSession('username_addons_v2')
             && $this->getFromSession('password_addons_v2');
+    }
+
+    private function hasAccountsTokenInSession(): bool
+    {
+        return null !== $this->getFromSession('accounts_token');
     }
 }

--- a/src/Api/Service/ModuleTransitionExecutor.php
+++ b/src/Api/Service/ModuleTransitionExecutor.php
@@ -104,6 +104,16 @@ class ModuleTransitionExecutor implements ServiceExecutorInterface
 
     private function authenticateAddonsUser(Session $session): void
     {
+        // If we receive an accounts_token, we use it to connect to addons
+        $accountsToken = Tools::getValue('accounts_token', null);
+
+        if (null !== $accountsToken) {
+            $session->set('accounts_token', $accountsToken);
+
+            return;
+        }
+
+        // If we don't have accounts_token, we try to connect with addons credentials
         $addonsUsername = Tools::getValue('addons_username', null);
         $addonsPwd = Tools::getValue('addons_pwd', null);
 

--- a/src/Distribution/ConnectedClient.php
+++ b/src/Distribution/ConnectedClient.php
@@ -56,11 +56,19 @@ class ConnectedClient extends BaseClient
         $credentials = [];
         if ($this->user->isAuthenticated()) {
             $credentials = $this->user->getCredentials(true);
-            $userCacheKey = md5($credentials['username'] . $credentials['password']);
-            $this->setQueryParams([
-               'addons_username' => $credentials['username'],
-               'addons_pwd' => $credentials['password'],
-            ]);
+
+            if (array_key_exists('accounts_token', $credentials)) {
+                $userCacheKey = md5($credentials['accounts_token']);
+                $this->setQueryParams([
+                    'accounts_token' => $credentials['accounts_token'],
+                ]);
+            } else {
+                $userCacheKey = md5($credentials['username'] . $credentials['password']);
+                $this->setQueryParams([
+                    'addons_username' => $credentials['username'],
+                    'addons_pwd' => $credentials['password'],
+                ]);
+            }
         }
 
         $cacheKey = __METHOD__ . $languageIsoCode . $countryIsoCode . $userCacheKey . _PS_VERSION_;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the MBO project! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 4.2.x
| Description?      | If accounts_token is given on module actions, use it as authentication for addons requests
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Partially Fixes MBO-504

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
