### PR TITLE
[MBO-728] Clear Sf cache on module disable or enable

### DIFF
--- a/config/services/addons.php
+++ b/config/services/addons.php
@@ -38,6 +38,7 @@ return static function (ContainerConfigurator $container) {
             ref('mbo.cdc.client.distribution_api'),
             ref('mbo.security.admin_authentication.provider'),
             ref('mbo.distribution.api_version_change_config_apply_handler'),
+            ref('prestashop.adapter.cache.clearer.symfony_cache_clearer'),
         ])
         ->public()
         ->tag('kernel.event_subscriber');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the MBO project! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 4.3.x
| Description?      | The Core subscriber clears Sf cache only when a module is installed or uninstalled. We need to clear it on enable/disable/enable-on-mobile/disable-on-mobile to avoid services errors
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes MBO-728
| How to test?      | Disable MBO, Go to Orders page, you will see no error

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
