### PR TITLE
Fix deprecation about `$usePutenv`

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -28,6 +29,6 @@ if (!$rootDir) {
     $rootDir = __DIR__ . '/../../';
 }
 
-require_once $rootDir.'/vendor/autoload.php';
+require_once $rootDir . '/vendor/autoload.php';
 
 (new \Symfony\Component\Dotenv\Dotenv(true))->loadEnv(__DIR__ . '/.env');

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -30,4 +30,4 @@ if (!$rootDir) {
 
 require_once $rootDir.'/vendor/autoload.php';
 
-(new \Symfony\Component\Dotenv\Dotenv())->loadEnv(__DIR__ . '/.env');
+(new \Symfony\Component\Dotenv\Dotenv(true))->loadEnv(__DIR__ . '/.env');

--- a/ps_mbo.php
+++ b/ps_mbo.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -17,6 +18,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
+
 declare(strict_types=1);
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -363,14 +365,14 @@ class ps_mbo extends Module
         }
 
         return $this->container->has('mbo.security.admin_authentication.provider') ?
-                $this->get('mbo.security.admin_authentication.provider') :
-                new AdminAuthenticationProvider(
-                    $this->get('doctrine.dbal.default_connection'),
-                    $this->context,
-                    $this->get('prestashop.core.crypto.hashing'),
-                    $this->get('doctrine.cache.provider'),
-                    $this->container->getParameter('database_prefix')
-                );
+            $this->get('mbo.security.admin_authentication.provider') :
+            new AdminAuthenticationProvider(
+                $this->get('doctrine.dbal.default_connection'),
+                $this->context,
+                $this->get('prestashop.core.crypto.hashing'),
+                $this->get('doctrine.cache.provider'),
+                $this->container->getParameter('database_prefix')
+            );
     }
 
     private function getModuleEnvVar(): string

--- a/ps_mbo.php
+++ b/ps_mbo.php
@@ -432,7 +432,7 @@ class ps_mbo extends Module
      */
     private function loadEnv(): void
     {
-        $dotenv = new Dotenv();
+        $dotenv = new Dotenv(true);
         $dotenv->loadEnv(__DIR__ . '/.env');
     }
 

--- a/src/Traits/HaveConfigurationPage.php
+++ b/src/Traits/HaveConfigurationPage.php
@@ -118,10 +118,11 @@ trait HaveConfigurationPage
                 'name' => "Prestabulle $i",
             ];
         }
-        $options = array_merge($options, [[
-            'value' => 'preprod',
-            'name' => 'Preprod',
-        ],
+        $options = array_merge($options, [
+            [
+                'value' => 'preprod',
+                'name' => 'Preprod',
+            ],
             [
                 'value' => 'prod',
                 'name' => 'Prod',

--- a/src/Traits/HaveConfigurationPage.php
+++ b/src/Traits/HaveConfigurationPage.php
@@ -94,7 +94,7 @@ trait HaveConfigurationPage
         file_put_contents($envFilePath, $envData);
 
         // Force reload of the .env file
-        $dotenv = new Dotenv();
+        $dotenv = new Dotenv(true);
         $dotenv->overload($envFilePath);
 
         return 'Configuration updated to <b>' . ucfirst($newValue) . "</b>.Don't forget to reset the module.";


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the MBO project! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 4.x
| Description?      | Sets default value of param `$usePutenv` explicitly on `dotenv` instances to avoid deprecation warnings.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #509
| How to test?      | Enable debug mode on the shop and check _var/logs/dev.log_ file. 
| Possible impacts? | None. Just setting default value explicitly.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
