### PR TITLE
[MBO-832] Version 1 : Always rely on tabCollection to display Recommended modules button

### DIFF
--- a/ps_mbo.php
+++ b/ps_mbo.php
@@ -605,10 +605,9 @@ class ps_mbo extends Module
         if (Validate::isLoadedObject($this->context->employee)) {
             /** @var TabCollectionProvider $tabCollectionProvider */
             $tabCollectionProvider = $this->get('mbo.tab.collection.provider');
-            if ($tabCollectionProvider->isTabCollectionCached()) {
-                return $tabCollectionProvider->getTabCollection()->getTab(Tools::getValue('controller'))->shouldDisplayButton()
-                    && 'AdminCarriers' !== Tools::getValue('controller');
-            }
+
+            return $tabCollectionProvider->getTabCollection()->getTab(Tools::getValue('controller'))->shouldDisplayButton()
+                && 'AdminCarriers' !== Tools::getValue('controller');
         }
 
         return in_array(Tools::getValue('controller'), static::TABS_WITH_RECOMMENDED_MODULES_BUTTON, true);


### PR DESCRIPTION
Use the list of tabs and recommended modules from PS API and the verification of modules exeistence to display or not recommended modules button