### PR TITLE
:ambulance: fix(Traits): Fix traits method collision

### DIFF
--- a/src/Traits/UseHooks.php
+++ b/src/Traits/UseHooks.php
@@ -31,9 +31,15 @@ trait UseHooks
 {
     use \PrestaShop\Module\Mbo\Traits\Hooks\UseDisplayBackOfficeEmployeeMenu;
     use \PrestaShop\Module\Mbo\Traits\Hooks\UseDashboardZoneOne;
+    use \PrestaShop\Module\Mbo\Traits\Hooks\UseDashboardZoneTwo {
+        \PrestaShop\Module\Mbo\Traits\Hooks\UseDashboardZoneOne::smartyDisplayTpl insteadof \PrestaShop\Module\Mbo\Traits\Hooks\UseDashboardZoneTwo;
+        \PrestaShop\Module\Mbo\Traits\Hooks\UseDashboardZoneOne::loadCdcMediaFilesForControllers insteadof \PrestaShop\Module\Mbo\Traits\Hooks\UseDashboardZoneTwo;
+    }
+    use \PrestaShop\Module\Mbo\Traits\Hooks\UseDashboardZoneThree {
+        \PrestaShop\Module\Mbo\Traits\Hooks\UseDashboardZoneOne::smartyDisplayTpl insteadof \PrestaShop\Module\Mbo\Traits\Hooks\UseDashboardZoneThree;
+        \PrestaShop\Module\Mbo\Traits\Hooks\UseDashboardZoneOne::loadCdcMediaFilesForControllers insteadof \PrestaShop\Module\Mbo\Traits\Hooks\UseDashboardZoneThree;
+    }
     use \PrestaShop\Module\Mbo\Traits\Hooks\UseDisplayAdminThemesListAfter;
-    use \PrestaShop\Module\Mbo\Traits\Hooks\UseDashboardZoneTwo;
-    use \PrestaShop\Module\Mbo\Traits\Hooks\UseDashboardZoneThree;
     use \PrestaShop\Module\Mbo\Traits\Hooks\UseDisplayDashboardTop;
     use \PrestaShop\Module\Mbo\Traits\Hooks\UseActionAdminControllerSetMedia;
     use \PrestaShop\Module\Mbo\Traits\Hooks\UseActionBeforeDisableModule;


### PR DESCRIPTION
Multiple traits use the same base method of another traits. Fix this by overriding the use with insteadof.