### PR TITLE
[MBO-1030] Do not add filterCategoryRef if category is other

### DIFF
--- a/src/Addons/Provider/LinksProvider.php
+++ b/src/Addons/Provider/LinksProvider.php
@@ -133,9 +133,12 @@ class LinksProvider
     {
         $category = $this->getCategoryByName($categoryName);
 
-        return $this->router->generate('admin_mbo_catalog_module', [
-            'filterCategoryRef' => $category ? $category->refMenu : '',
-        ]);
+        $routeParams = [];
+        if ($category && 'other' !== mb_strtolower($categoryName)) {
+            $routeParams['filterCategoryRef'] = $category->refMenu;
+        }
+
+        return $this->router->generate('admin_mbo_catalog_module', $routeParams);
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the MBO project! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 4.4.x
| Description?      | There is no category Other. The category Other is to classify modules without category in Module Manager. There was a bug when you click to see more modules in Category Other so we decide to redirect to the main page of the marketplace
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes MBO-1030
| How to test?      | Go to Module Manager, scroll to the bottom, click on See more modules on category Other. You will be redirected to the marketplace main page without category filter.<br><br>Click on another category, you will be still redirected to the marketplace with the category filter filled

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
