### PR TITLE
Addons ApiClient - Make domain optional to fix PS install

### DIFF
--- a/src/Addons/ApiClient.php
+++ b/src/Addons/ApiClient.php
@@ -74,7 +74,7 @@ class ApiClient
         $this->httpClient = $httpClient;
     }
 
-    public function setDefaultParams(string $locale, $isoCode, string $domain, string $shopVersion)
+    public function setDefaultParams(string $locale, $isoCode, ?string $domain, string $shopVersion)
     {
         list($isoLang) = explode('-', $locale);
         $this->setQueryParams([


### PR DESCRIPTION
_PS_BASE_URL_ is not defined in install process. So the domain is null

We make it optional on installation mode