### PR TITLE
[MBO-1524] Add service modules helper + Implement method to find updates for a module

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ This module is compatible with the multistore :heavy_check_mark:
 
 Once installed it's available whatever the shop context
 
+## Tools and helpers
+
+MBO provides some tools for developers to gather informations on modules
+
+- [Update infos][tools-update-infos]
+
 ## Translations
 
 See [translations-docs][translations-docs]
@@ -84,3 +90,4 @@ This module is released under the [Academic Free License 3.0][AFL-3.0]
 [coding-standards]: https://devdocs.prestashop.com/1.7/development/coding-standards/
 [AFL-3.0]: https://opensource.org/licenses/AFL-3.0
 [translations-docs]: docs/translations.md
+[tools-update-infos]: docs/tools-update-infos.md

--- a/config/services/modules.yml
+++ b/config/services/modules.yml
@@ -50,3 +50,4 @@ services:
     class: PrestaShop\Module\Mbo\Service\ModulesHelper
     arguments:
       - '@mbo.modules.repository'
+      - '@router'

--- a/config/services/modules.yml
+++ b/config/services/modules.yml
@@ -45,3 +45,8 @@ services:
       $addonsUrlSourceRetriever: '@mbo.modules.state_machine.source_retriever.url'
       $zipSourceHandler: '@prestashop.module.sourcehandler.zip'
     tags: [ core.module.source_handler ]
+
+  mbo.modules.helper:
+    class: PrestaShop\Module\Mbo\Service\ModulesHelper
+    arguments:
+      - '@mbo.modules.repository'

--- a/docs/tools-update-infos.md
+++ b/docs/tools-update-infos.md
@@ -1,0 +1,71 @@
+## Usage
+
+```
+try {
+    dump($this->get('mbo.modules.helper')->findForUpdates('productcomments'));
+} catch (\Exception $e) {
+    ErrorHelper::reportError($e);
+    throw $e;
+}
+```
+
+### Return values
+
+```
+[
+  "current_version" => "5.0.2"
+  "available_version" => "6.0.2"
+  "upgrade_available" => true,
+  'urls' => [
+      'install' => null,
+      'upgrade' => '/manage/action/upgrade/productcomments',
+   ]
+]
+```
+If the module is installed and do have an upgrade
+
+
+============================================================
+
+```
+[
+  "current_version" => "5.0.2"
+  "available_version" => "5.0.2"
+  "upgrade_available" => false,
+  'urls' => [
+      'install' => null,
+      'upgrade' => null,
+   ]
+]
+```
+If the module is installed but doesn't have an upgrade
+
+============================================================
+
+```
+[
+  "current_version" => null
+  "available_version" => "5.0.2"
+  "upgrade_available" => false,
+  'urls' => [
+      'install' => '/manage/action/install/productcomments',
+      'upgrade' => null,
+   ]
+]
+```
+If the module is not installed but exists on Addons
+
+============================================================
+
+```
+[
+  "current_version" => null
+  "available_version" => null
+  "upgrade_available" => false,
+  'urls' => [
+      'install' => null,
+      'upgrade' => null,
+   ]
+]
+```
+If the module is not installed and doesn't exist on Addons

--- a/src/Module/Repository.php
+++ b/src/Module/Repository.php
@@ -111,13 +111,24 @@ class Repository implements RepositoryInterface
     {
         if ($this->cache !== null) {
             $this->cacheProvider->save($this->cacheName, $this->cache, 60 * 60 * 24); // A day of cache maximum.
+            $this->cacheProvider->save($this->cacheName . '_time', time(), 60 * 60 * 24); // A day of cache maximum.
         }
     }
 
     public function clearCache(): void
     {
         $this->cacheProvider->delete($this->cacheName);
+        $this->cacheProvider->delete($this->cacheName . '_time');
         $this->cache = null;
+    }
+
+    public function getCacheAge(): ?int
+    {
+        if ($this->cacheProvider->contains($this->cacheName . '_time')) {
+            return $this->cacheProvider->fetch($this->cacheName . '_time');
+        }
+
+        return null;
     }
 
     public function fetchAll(bool $rawModules = false): array

--- a/src/Service/ModulesHelper.php
+++ b/src/Service/ModulesHelper.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\Mbo\Service;
+
+use PrestaShop\Module\Mbo\Module\Repository;
+
+class ModulesHelper
+{
+    /**
+     * @var Repository
+     */
+    private $moduleRepository;
+
+    public function __construct(Repository $repository)
+    {
+        $this->moduleRepository = $repository;
+    }
+
+    public function findForUpdates(string $moduleName): array
+    {
+        $currentVersion = $availableVersion = null;
+        $upgradeAvailable = false;
+
+        $db = \Db::getInstance();
+        $request = 'SELECT `version` FROM `' . _DB_PREFIX_ . "module` WHERE name='" . $moduleName . "'";
+
+        /** @var string|false $moduleCurrentVersion */
+        $moduleCurrentVersion = $db->getValue($request);
+
+        if ($moduleCurrentVersion) {
+            $currentVersion = $moduleCurrentVersion;
+        }
+
+        // We need to clear cache to get fresh data from addons
+        $this->moduleRepository->clearCache();
+
+        $module = $this->moduleRepository->getApiModule($moduleName);
+
+        if (null !== $module) {
+            $availableVersion = (string)$module->version_available;
+
+            // If the current installed version is greater or equal than the one returned by Addons, an upgrade is available
+            if (
+                null !== $availableVersion
+                && null !== $currentVersion
+                && version_compare($availableVersion, $currentVersion, 'gt')
+            ) {
+                $upgradeAvailable = true;
+            }
+        }
+
+        return [
+            'current_version' => $currentVersion,
+            'available_version' => $availableVersion,
+            'upgrade_available' => $upgradeAvailable,
+        ];
+    }
+}


### PR DESCRIPTION
## Usage

```
$this->get('mbo.modules.helper')->findForUpdates('productcomments')
```

will return

```
[
  "current_version" => "5.0.2"
  "available_version" => "6.0.2"
  "upgrade_available" => true,
  'urls' => [
      'install' => null,
      'upgrade' => '/manage/action/upgrade/productcomments',
   ]
]
```
If the module is installed and do have an upgrade


============================================================

```
[
  "current_version" => "5.0.2"
  "available_version" => "5.0.2"
  "upgrade_available" => false,
  'urls' => [
      'install' => null,
      'upgrade' => null,
   ]
]
```
If the module is installed but doesn't have an upgrade

============================================================

```
[
  "current_version" => null
  "available_version" => "5.0.2"
  "upgrade_available" => false,
  'urls' => [
      'install' => '/manage/action/install/productcomments',
      'upgrade' => null,
   ]
]
```
If the module is not installed but exists on Addons

============================================================

```
[
  "current_version" => null
  "available_version" => null
  "upgrade_available" => false,
  'urls' => [
      'install' => null,
      'upgrade' => null,
   ]
]
```
If the module is not installed and doesn't exists on Addons