### PR TITLE
fix: remove deprecated array merge on smarty

### DIFF
--- a/views/templates/admin/controllers/module_catalog/catalog.html.twig
+++ b/views/templates/admin/controllers/module_catalog/catalog.html.twig
@@ -32,9 +32,10 @@
       {# PrestaShop Account #}
       <script src="{{ urlAccountsCdn }}" rel=preload></script>
       <script>
+        var psAccountLoaded = false;
         if (window?.psaccountsVue) {
           window?.psaccountsVue?.init();
-          {% set shop_context = shop_context|merge({'accounts_component_loaded': true}) %}
+          psAccountLoaded = true;
         }
       </script>
     {% endif %}
@@ -50,6 +51,10 @@
         const renderModules = window.mboCdc.renderModules
 
         const context = {{ shop_context|json_encode()|raw }};
+
+        if (psAccountLoaded) {
+          context.accounts_component_loaded = true;
+        }
 
         renderModules(context, '#cdc-container')
       }

--- a/views/templates/hook/dashboard-zone-one.tpl
+++ b/views/templates/hook/dashboard-zone-one.tpl
@@ -38,9 +38,10 @@
 {if isset($urlAccountsCdn)}
   <script src="{$urlAccountsCdn}" rel=preload></script>
   <script>
+    var psAccountLoaded = false;
     if (window?.psaccountsVue) {
       window?.psaccountsVue?.init();
-      {assign shop_context $shop_context|@json_decode:true|array_merge:['accounts_component_loaded' => true]|@json_encode}
+      psAccountLoaded = true;
     }
   </script>
 {/if}
@@ -56,6 +57,10 @@
     const renderTipsAndUpdate = window.mboCdc.renderDashboardTipsAndUpdate
 
     const dashboardTipsAndUpdateContext = {$shop_context};
+
+    if (psAccountLoaded) {
+      dashboardTipsAndUpdateContext.accounts_component_loaded = true;
+    }
 
     renderTipsAndUpdate(dashboardTipsAndUpdateContext, '#cdc-tips-and-update-container')
   }


### PR DESCRIPTION
Fix #763 