### PR TITLE
Fix Sentry HTTP transport blocking PHP-FPM workers on quota exceeded

### DIFF
--- a/src/Handler/ErrorHandler/ErrorHandler.php
+++ b/src/Handler/ErrorHandler/ErrorHandler.php
@@ -62,6 +62,8 @@ class ErrorHandler implements ErrorHandlerInterface
                 'environment' => EnvHelper::getEnv('SENTRY_ENVIRONMENT'),
                 'traces_sample_rate' => 0.5,
                 'sample_rate' => 0.5,
+                'http_timeout' => 2,
+                'http_connect_timeout' => 1,
             ]);
 
             \Sentry\configureScope(function (Scope $scope): void {


### PR DESCRIPTION
## Problem

Without `http_timeout` configured, the synchronous `HttpTransport` used by `sentry/sdk ^3.3` can block a PHP-FPM worker indefinitely when Sentry is slow to respond.

The `ErrorListenerIntegration` global hook registered by `\Sentry\init()` intercepts **all unhandled exceptions** — not only explicit `handle()` calls. This means any request that hits an error stalls the worker on `curl_multi_select()` inside `HttpTransport::send()` until Sentry responds.

When the monthly Sentry quota is reached (429 response), `RetryPlugin` from `php-http/client-common` retries the request before releasing the worker, multiplying the blocking time.

Observed blocking call stack (from PHP-FPM slow log, `request_slowlog_timeout = 5s`):
```
curl_multi_select()                               ← blocked here
  CurlResponse::select()
  ResponseTrait::stream()
  HttplugWaitLoop::wait()
  HttplugClient::wait()
  HttpTransport::send()                           ← sentry/sentry
  Sentry\Client::captureEvent()
  Sentry\Client::captureException()
  ErrorListenerIntegration::captureException()    ← global hook
```

**Observed in production**: load average ~7/8 on an 8-core server, PHP-FPM slow pool oscillating every 2–3 minutes (DeltaBlue auto-scaling `pm.max_children` between 48 and 56), caused by workers stalling 5–30s on Sentry captures during a quota-exceeded period.

## Fix

Add `http_timeout` and `http_connect_timeout` to the `\Sentry\init()` call. Both are natively supported options in `sentry/sentry` v3.x, passed through to the underlying cURL transport.

## Test

Tested on a PrestaShop staging server with `ps_mbo` installed:

```
Without http_timeout (current behavior):  4.02s blocked per exception capture
With    http_timeout=2 (this fix):        2.00s  (capped, regardless of Sentry availability)
```

Script used: instantiated `\Sentry\init()` with a non-routable DSN (`10.255.255.1`) to simulate Sentry being unresponsive (equivalent to quota exceeded / network timeout), then called `\Sentry\captureException()` and measured wall time.

## Note on other PS modules

Five other PrestaShop modules on the same server also use Sentry (`ps_accounts`, `psshipping`, `psxdesign`, `ps_checkout`, `psxmarketingwithgoogle`). They all use the legacy `Raven_Client` SDK which has a **hardcoded 2s default timeout** (`$this->timeout = Raven_Util::get($options, 'timeout', 2)`). Only `ps_mbo` migrated to `sentry/sdk ^3.x` and is affected by this regression.