### PR TITLE
fix: rename Sentry env vars to PS_MBO_ prefix (SM-409)

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,7 +1,7 @@
 MBO_CDC_URL="https://assets.prestashop3.com/dst/mbo/v1/mbo-cdc.umd.js"
 DISTRIBUTION_API_URL="https://mbo-api.prestashop.com"
-SENTRY_CREDENTIALS="https://aa99f8a351b641af994ac50b01e14e20@o298402.ingest.sentry.io/6520457"
-SENTRY_ENVIRONMENT="production"
+PS_MBO_SENTRY_CREDENTIALS="https://aa99f8a351b641af994ac50b01e14e20@o298402.ingest.sentry.io/6520457"
+PS_MBO_SENTRY_ENVIRONMENT="production"
 ADDONS_API_URL="https://api-addons.prestashop.com"
 
 # For testing purpose only

--- a/src/Handler/ErrorHandler/ErrorHandler.php
+++ b/src/Handler/ErrorHandler/ErrorHandler.php
@@ -49,7 +49,7 @@ class ErrorHandler implements ErrorHandlerInterface
 
     public function __construct()
     {
-        $this->dsn = EnvHelper::getEnv('SENTRY_CREDENTIALS');
+        $this->dsn = EnvHelper::getEnv('PS_MBO_SENTRY_CREDENTIALS');
 
         if (empty($this->dsn)) {
             return;
@@ -59,7 +59,7 @@ class ErrorHandler implements ErrorHandlerInterface
             \Sentry\init([
                 'dsn' => $this->dsn,
                 'release' => \ps_mbo::VERSION,
-                'environment' => EnvHelper::getEnv('SENTRY_ENVIRONMENT'),
+                'environment' => EnvHelper::getEnv('PS_MBO_SENTRY_ENVIRONMENT'),
                 'traces_sample_rate' => 0.5,
                 'sample_rate' => 0.5,
             ]);

--- a/src/Traits/HaveConfigurationPage.php
+++ b/src/Traits/HaveConfigurationPage.php
@@ -140,9 +140,9 @@ trait HaveConfigurationPage
         $envData = preg_replace('#MBO_CDC_URL=".*"#', 'MBO_CDC_URL="' . $cdcUrl . '"', $envData);
         $envData = preg_replace('#DISTRIBUTION_API_URL=".*"#', 'DISTRIBUTION_API_URL="' . $apiUrl . '"', $envData);
         $envData = preg_replace('#ADDONS_API_URL=".*"#', 'ADDONS_API_URL="' . $addonsUrl . '"', $envData);
-        $envData = preg_replace('#SENTRY_CREDENTIALS=".*"#', 'SENTRY_CREDENTIALS="' . $sentryUrl . '"', $envData);
+        $envData = preg_replace('#PS_MBO_SENTRY_CREDENTIALS=".*"#', 'PS_MBO_SENTRY_CREDENTIALS="' . $sentryUrl . '"', $envData);
         $envData =
-            preg_replace('#SENTRY_ENVIRONMENT=".*"#', 'SENTRY_ENVIRONMENT="' . $sentryEnvironment . '"', $envData);
+            preg_replace('#PS_MBO_SENTRY_ENVIRONMENT=".*"#', 'PS_MBO_SENTRY_ENVIRONMENT="' . $sentryEnvironment . '"', $envData);
 
         // Update the .env file
         file_put_contents($envFilePath, $envData);


### PR DESCRIPTION
## Summary

- Renames `SENTRY_CREDENTIALS` to `PS_MBO_SENTRY_CREDENTIALS`
- Renames `SENTRY_ENVIRONMENT` to `PS_MBO_SENTRY_ENVIRONMENT`
- Updates all read/write usages across `ErrorHandler.php`, `HaveConfigurationPage.php`, and `.env.dist`

**Why:** Generic names conflicted with variables in other `.env` files on shared servers, causing `ErrorHandler` to initialize Sentry unintentionally.

## Files changed

- `src/Handler/ErrorHandler/ErrorHandler.php`: updated two `EnvHelper::getEnv()` calls
- `src/Traits/HaveConfigurationPage.php`: updated two `preg_replace()` patterns and replacement strings
- `.env.dist`: updated variable names in the template

## Test plan

- [ ] Deploy to a test/staging env and verify Sentry still initializes correctly with the new var names
- [ ] Verify that if `SENTRY_CREDENTIALS` exists in another `.env` on the same server, ps_mbo no longer picks it up

Closes SM-409

🤖 Generated with [Claude Code](https://claude.com/claude-code)