### PR TITLE
chore: bump GitHub Actions versions in CI/CD workflows (SM-401)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: 'actions/checkout@v4'
+        uses: 'actions/checkout@v6'
         with:
           path: ''
 
@@ -30,7 +30,7 @@ jobs:
         uses: 'PrestaShopCorp/github-action-clean-before-deploy@v2.0'
 
       - name: Cache module folder
-        uses: 'actions/cache@v4'
+        uses: 'actions/cache@v5'
         with:
           path: ./
           key: ${{ github.run_id }}
@@ -46,7 +46,7 @@ jobs:
 
       - name: Retrieve from cache module folder
         id: retrieve-cache
-        uses: 'actions/cache@v4'
+        uses: 'actions/cache@v5'
         with:
           path: ./
           key: ${{ github.run_id }}
@@ -99,7 +99,7 @@ jobs:
 
       - name: Retrieve from cache module folder
         id: retrieve-cache
-        uses: 'actions/cache@v4'
+        uses: 'actions/cache@v5'
         with:
           path: ./
           key: ${{ github.run_id }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: PHP syntax checker 8.1
         uses: prestashop/github-action-php-lint/8.1@master
       - name: PHP syntax checker 8.2
@@ -23,7 +23,7 @@ jobs:
           php-version: 8.1
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate composer config
         run: composer validate --strict
@@ -51,18 +51,18 @@ jobs:
           php-version: ${{ matrix.php-version }})
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Add vendor folder in cache to make next builds faster
       - name: Cache vendor folder
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: vendor
           key: php-${{ hashFiles('composer.lock') }}
 
       # Add composer local folder in cache to make next builds faster
       - name: Cache composer folder
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.composer/cache
           key: php-composer-cache
@@ -86,18 +86,18 @@ jobs:
           php-version: 8.1
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Add vendor folder in cache to make next builds faster
       - name: Cache vendor folder
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: vendor
           key: php-${{ hashFiles('composer.lock') }}
 
       # Add composer local folder in cache to make next builds faster
       - name: Cache composer folder
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.composer/cache
           key: php-composer-cache

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -10,7 +10,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'translations_update')
     steps:
       - name: Checkout module-translation-tool
-        uses: actions/checkout@v2.0.0
+        uses: actions/checkout@v6
         with:
           repository: PrestaShopCorp/module-translation-tool
           ref: main


### PR DESCRIPTION
## Summary

- `actions/checkout`: v2/v4 -> v6 (3 workflow files)
- `actions/cache`: v3/v4 -> v5 (2 workflow files)
- All `actions/cache` usages already had explicit `path` parameters set

## Test Plan

- [ ] CI passes on this PR (php-linter, php-cs-fixer, phpstan, phpunit)

Closes SM-401

🤖 Generated with [Claude Code](https://claude.com/claude-code)