### PR TITLE
chore: set up AI developer context (SM-380)

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,64 @@
+---
+name: code-reviewer
+description: Reviews PHP/PrestaShop code changes for correctness, security, and compliance with ps_mbo conventions. Use for PRs, feature branches, or any diff review.
+tools: Read, Grep, Glob, Bash
+memory: project
+---
+
+You are a senior PHP engineer specializing in PrestaShop module development. You review code for the `ps_mbo` module.
+
+## Project context
+
+- PHP 8.1+, `declare(strict_types=1)` required in every file
+- PSR-12 code style
+- PrestaShop 8.x / 9.x compatibility (entry guard: `version_compare(_PS_VERSION_, '8.0.2', '<')`)
+- Symfony 6.4 DI container: all services must be `public: true`
+- One hook = one trait in `src/Traits/Hooks/`; boot logic in `boot{TraitName}()`
+- No class overrides — hooks only
+- `HaveConfigurationPage` is stripped in production builds; never put production logic there
+- Legacy `src/Api/` and `controllers/admin/apiPsMbo.php` are v8 remnants — do not suggest extending them
+
+## Review checklist
+
+### Correctness
+- Logic errors, off-by-one, null/undefined handling
+- Edge cases for both authenticated (ConnectedClient) and anonymous (Client) shops
+- Proper hook return values (some hooks expect specific types or null)
+
+### Security
+- No SQL injection (use PS `Db::getInstance()->escape()` or Doctrine)
+- No XSS (escape output in Twig with `| escape` / in Smarty with `{$var|escape}`)
+- No hardcoded credentials or API keys
+- Guzzle requests: verify TLS is not disabled, no user-controlled URLs without validation
+
+### PrestaShop conventions
+- `declare(strict_types=1)` at top of every PHP file
+- PSR-12 formatting
+- Hook traits: each has its own file, boot method follows `boot{TraitName}()` naming
+- DI services: `public: true` in YAML config
+- Environment-dependent values come from `.env` / container parameters, never hardcoded
+
+### Architecture
+- New functionality goes through Symfony services, not procedural code in the main class
+- Distribution API calls use `Client` (anonymous) or `ConnectedClient` (authenticated) — not raw Guzzle
+- Module source resolution uses `SourceHandlerInterface` pattern, not direct download calls
+
+### Tests
+- PHPUnit 9.x conventions
+- New logic has test coverage
+- No test bypasses (`@covers` on wrong class, untested public methods in non-trivial classes)
+
+## Output format
+
+Structure your review as:
+
+**Summary**: one sentence on the overall quality.
+
+**Findings**: grouped by severity — Critical, Major, Minor, Nit. Each finding:
+- Location (file:line)
+- What the problem is
+- Concrete fix (code snippet when relevant)
+
+**Positives**: note patterns done well, especially if they correct a past anti-pattern.
+
+If there is nothing to flag in a category, omit it. Be direct; do not pad the review.

--- a/.claude/rules/di-config.md
+++ b/.claude/rules/di-config.md
@@ -1,0 +1,52 @@
+---
+paths:
+  - "config/services/**/*.yml"
+  - "config/services/**/*.yaml"
+  - "config/services/**/*.php"
+---
+
+# Symfony DI configuration conventions
+
+## Public services
+
+All services must be reachable via `$this->get()` from legacy PS code. The `_defaults` block already sets `public: true` in each YAML file — do not remove it, and do not set `public: false` on individual services.
+
+## Environment variables
+
+API base URLs and credentials must come from env vars:
+
+```yaml
+arguments:
+  $apiUrl: "%env(DISTRIBUTION_API_URL)%"
+```
+
+Never hardcode any URL directly in YAML.
+
+## Autowire
+
+- Use `autowire: true` only when constructor arguments can be resolved unambiguously from type hints
+- If a service needs explicit `$apiUrl`, `$httpClient`, or other non-typed scalar args, list them under `arguments:` explicitly
+- Do not mix `autowire: true` with a full `arguments:` block — pick one approach
+
+## Factory pattern
+
+For services built via a static factory method (e.g. Doctrine cache wrappers):
+
+```yaml
+factory: [ ClassName, staticMethodName ]
+arguments:
+  $pool: '@DependencyServiceId'
+```
+
+## File ownership
+
+| File | Owns |
+|------|------|
+| `distribution.yml` | Distribution API clients and cache |
+| `addons.yml` / `addons.php` | Addons API client and source handler |
+| `accounts.yml` | ps_accounts integration services |
+| `cdc.yml` | CDC context builder and related services |
+| `modules.yml` | Module collection, repository, builder |
+| `security.yml` | HMAC verifier and legacy API security (v8 remnant, read-only) |
+
+Add new services to the file that owns their domain; do not dump everything into a catch-all file.

--- a/.claude/rules/hook-traits.md
+++ b/.claude/rules/hook-traits.md
@@ -1,0 +1,68 @@
+---
+paths:
+  - "src/Traits/Hooks/*.php"
+  - "src/Traits/*.php"
+---
+
+# Hook trait conventions
+
+## File structure
+
+Every hook trait must follow this order:
+1. License header (AFL 3.0 block comment)
+2. `declare(strict_types=1);`
+3. `namespace PrestaShop\Module\Mbo\Traits\Hooks;`
+4. `use` statements
+5. `if (!defined('_PS_VERSION_')) { exit; }`
+6. `trait Use{HookName}`
+
+## Service access
+
+- Always retrieve services via `$this->get(ServiceClass::class)`, never via `new`
+- After `$this->get()`, check for `null` and throw `ExpectedServiceNotFoundException` if required
+- Wrap service retrieval in try/catch; on exception call `ErrorHelper::reportError($e)` then return `''` (not `false`)
+
+## Hook return types
+
+- Display hooks (`hookDisplay*`, `hookDashboard*`): return type `false|string`, return `''` on error (not `false`)
+- Action hooks (`hookAction*`): typically `void` or `array`; document expected shape if array
+
+## NEVER let an exception escape a hook
+
+A hook is called inside a PrestaShop workflow (module install, page render, module list build...). An uncaught exception propagates up and breaks the entire workflow for the merchant, not just this module.
+
+**Every hook method must be wrapped in a top-level try/catch(\Throwable).** No exception — checked or unchecked — may bubble out.
+
+```php
+// WRONG — exception escapes, breaks the PS workflow
+public function hookActionListModules(array $params): array
+{
+    $service = $this->get(MyService::class); // throws if container not ready
+    return $service->enrich($params['list']);
+}
+
+// CORRECT
+public function hookActionListModules(array $params): array
+{
+    try {
+        $service = $this->get(MyService::class);
+        if (null === $service) {
+            throw new ExpectedServiceNotFoundException('...');
+        }
+        return $service->enrich($params['list']);
+    } catch (\Throwable $e) {
+        ErrorHelper::reportError($e);
+        return [];
+    }
+}
+```
+
+Return a safe neutral value on failure: `''` for display hooks, `[]` for hooks returning arrays, the unmodified input for hooks enriching a list.
+
+## Boot method
+
+Each trait must have a `boot{TraitName}()` method (e.g. `bootUseDashboardZoneOne()`) called by `UseHooks::bootHooks()`. Put any per-hook service initialization here, not in the hook method itself.
+
+## CDC-injecting hooks
+
+Hooks that inject CDC content must call `$this->smartyDisplayTpl()` from `HaveCdcComponent`, not Smarty directly. The `admin_mbo_module_cdc_error` route must be assigned before rendering.

--- a/.claude/rules/templates.md
+++ b/.claude/rules/templates.md
@@ -1,0 +1,32 @@
+---
+paths:
+  - "views/templates/**/*.tpl"
+  - "views/templates/**/*.html.twig"
+---
+
+# Template conventions
+
+## Escaping
+
+- **Smarty**: always escape user-facing output with `{$var|escape:'html':'UTF-8'}` or `{$var|escape}`
+- **Twig**: use `{{ var | e }}` or `{{ var }}` (auto-escape is on); disable with `| raw` only for trusted HTML built server-side
+
+## No logic in templates
+
+Templates must only display data already prepared by the controller or hook method. No service calls, no `Db` queries, no business logic. Move any conditional logic to the PHP side and pass a boolean flag.
+
+## CDC templates (`.tpl` in `hook/`)
+
+- The CDC JS bundle URL comes from the `$mbo_cdc_url` Smarty variable, never hardcoded
+- Do not reference `assets.prestashop3.com` or any CDN URL directly
+- The error fallback URL comes from the `$mbo_error_url` variable set by `HaveCdcComponent::smartyDisplayTpl()`
+
+## Twig admin templates
+
+- Extend `@PrestaShop/Admin/layout.html.twig` for full-page views, or `layout-ajax.html.twig` for AJAX-loaded panels
+- Use `{{ path('route_name') }}` for internal URLs, never string concatenation
+- Translation strings: `{{ 'key'|trans({}, 'Admin.Modules.Feature') }}`
+
+## Asset loading
+
+- JS/CSS assets are registered via the controller's `Media` calls or Smarty `{addjs}`/`{addcss}`, not inline `<script>` or `<style>` tags in templates

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,32 @@
+---
+paths:
+  - "tests/**/*.php"
+---
+
+# Testing conventions
+
+## Framework and base classes
+
+- PHPUnit 9.x
+- Use `MockeryTestCase` (from `mockery/mockery`) when you need expressive mock expectations; use `createMock()` for simple stubs
+- Workflow tests extend `AbstractTransitionTest` — check it for helper methods before writing boilerplate
+- Namespace mirrors `src/`: `PrestaShop\Module\Mbo\Tests\*`
+
+## Test structure
+
+- `@dataProvider` for all parametrized cases; provider method name must be referenced in the docblock
+- Provider methods return `yield` expressions, not arrays, for readability
+- `setUp()` initializes shared state; each test method is self-contained beyond that
+- `declare(strict_types=1)` is NOT required in test files (unlike `src/`)
+
+## What to test
+
+- Unit tests for pure logic (Filters, Workflow transitions, VO construction)
+- Mock external dependencies (Distribution API clients, PS `Db`, `Module`) — not internal collaborators
+- Do not test the PS framework itself; test the module's own behavior
+
+## Assertions
+
+- `assertEquals` for value equality, `assertSame` when type matters
+- `expectException(FooException::class)` before the call that throws, never in `catch`
+- Avoid `assertTrue(true)` or empty test bodies

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,20 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(composer install)",
+      "Bash(composer install *)",
+      "Bash(composer require *)",
+      "Bash(composer update *)",
+      "Bash(composer remove *)",
+      "Bash(composer dump-autoload *)",
+      "Bash(composer test)",
+      "Bash(composer lint)",
+      "Bash(php -d date.timezone=UTC ./vendor/bin/phpunit *)",
+      "Bash(./vendor/bin/phpunit *)",
+      "Bash(./vendor/bin/phpstan *)",
+      "Bash(./vendor/bin/php-cs-fixer *)",
+      "Bash(make build-zip)",
+      "Bash(make build-zip-prod)"
+    ]
+  }
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Export-ignore: excluded from git archive exports and production artifacts
+.ai-tools/  export-ignore
+.claude/    export-ignore
+CLAUDE.md   export-ignore

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -76,6 +76,10 @@ jobs:
         run: |
           rm -f gha-*.json
 
+      - name: Remove AI context files
+        run: |
+          rm -rf .ai-tools/ .claude/ CLAUDE.md
+
       - name: Prepare the zip
         run: |
           cd ..
@@ -130,6 +134,10 @@ jobs:
           rm -f gha-*.json
           rm -f ./src/Traits/HaveConfigurationPage.php
           sed -i '/HaveConfigurationPage/d' ps_mbo.php
+
+      - name: Remove AI context files
+        run: |
+          rm -rf .ai-tools/ .claude/ CLAUDE.md
 
       - name: Prepare the production zip
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".ai-tools"]
+	path = .ai-tools
+	url = git@github.com:PrestaShopCorp/marketplace-ai-tools.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,8 +120,7 @@ ModuleManager::install($name, source=null)
 `SourceHandlerInterface` and is registered in the DI container so the source
 factory picks it up automatically when the caller provides an Addons URL.
 
-The hook is therefore a fallback: it covers call sites that don't pass a source
-(e.g. back-office module manager triggered by name).
+The hook is therefore a fallback: it covers call sites that don't pass a source.
 
 Symfony Workflow (`symfony/workflow`) models the allowed transitions between
 module states (installed, enabled, upgraded, etc.).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,87 +2,215 @@
 
 ## Role in the Ecosystem
 
-PrestaShop module (Back-Office) that surfaces the Addons catalog, manages module
-installation/upgrade lifecycles, and integrates with PrestaShop Accounts, the
-MBO distribution API, and the Addons API.
+`ps_mbo` is a PrestaShop back-office module. Its two core responsibilities:
+
+1. **Addons catalog UI**: injects a Cross Domain Component (CDC) served by
+   `mbo.prestashop.com` that renders the full Addons marketplace inside the PS
+   back-office (module catalog, theme catalog, recommended modules).
+2. **Remote module management**: exposes a signed HTTP API so that the MBO
+   back-end (`mbo.prestashop.com`) can remotely trigger module
+   install/upgrade/uninstall actions on a merchant shop.
 
 Ecosystem map: `.ai-tools/ECOSYSTEM_CONTEXT.md`
 
 Key upstream/downstream:
-- `mbo.prestashop.com` feeds module data to this module (Distribution API)
-- `ps_mbo` downloads zip artifacts from `addons.prestashop.com`
-- Accounts integration via `prestashop/prestashop-accounts-installer`
+- `mbo.prestashop.com` -> `ps_mbo`: serves the CDC JS bundle and calls the
+  remote API endpoint to manage modules
+- `ps_mbo` -> Distribution API (`https://mbo-api.prestashop.com`): fetches
+  module catalogue data (authenticated and anonymous)
+- `ps_mbo` -> Addons API (`https://api-addons.prestashop.com`): downloads
+  module zip files for install/upgrade
+- `ps_mbo` requires `ps_accounts` to be installed; the Accounts JWT token is
+  forwarded to the Distribution API for authenticated calls
 
 ## Stack
 
-- PHP 8.1+, strict_types everywhere
+- PHP 8.1+, `declare(strict_types=1)` everywhere
 - PrestaShop 8.x / 9.x (entry guard: `version_compare(_PS_VERSION_, '8.0.2', '<')`)
-- Symfony 6.4 (DI container, Workflow, String)
+- Symfony 6.4 (DI container, Workflow, String components)
+- Guzzle HTTP (via PSR-18 interfaces) for outbound API calls
+- Smarty (hook templates) + Twig (Symfony controller views)
 - PHPUnit 9.x, PHP-CS-Fixer 3.x, PHPStan 1.x
 
 ## Architecture
 
 ### Main class composition
 
-`ps_mbo.php` extends `Module` and composes behaviour via three traits:
+`ps_mbo.php` extends PrestaShop's `Module` and composes all behaviour via traits:
 
 ```
 ps_mbo
-  UseHooks              - registers/dispatches all PS hooks
-    Hooks\UseXxx...     - one file per hook in src/Traits/Hooks/
-  HaveTabs              - admin tab registration
-  HaveConfigurationPage - admin config page (stripped from production builds)
+  UseHooks              (src/Traits/UseHooks.php)
+    Hooks\UseDashboardZoneOne
+    Hooks\UseDashboardZoneThree
+    Hooks\UseDisplayAdminThemesListAfter
+    Hooks\UseDisplayDashboardTop
+    Hooks\UseActionBeforeInstallModule
+    Hooks\UseActionBeforeUpgradeModule
+    Hooks\UseActionGetAlternativeSearchPanels
+    Hooks\UseActionListModules
+    Hooks\UseDisplayEmptyModuleCategoryExtraMessage
+  HaveTabs              (src/Traits/HaveTabs.php)
+  HaveConfigurationPage (src/Traits/HaveConfigurationPage.php) — dev only
+  HaveCdcComponent      (src/Traits/HaveCdcComponent.php)
 ```
 
-Each PS hook lives in its own trait file (`src/Traits/Hooks/UseXxxHook.php`).
-`UseHooks::bootHooks()` calls `bootXxx()` on each trait at module init.
+Each PS hook lives in its own file under `src/Traits/Hooks/`. `UseHooks::bootHooks()`
+calls `boot{TraitName}()` on each hook trait at module init, allowing per-hook
+service initialization without a monolithic `__construct`.
 
-### Service layer
+### CDC (Cross Domain Component)
 
-Symfony container defined in `config/services/` (YAML + one PHP file for Addons).
-`src/DependencyInjection/ContainerProvider.php` exposes the container to
-legacy PS code.
+The Addons catalog UI is **not** built in this repo. It is a compiled JS bundle
+(`mbo-cdc.umd.js`) hosted on the MBO CDN (`MBO_CDC_URL` env var, default:
+`https://assets.prestashop3.com/dst/mbo/v1/mbo-cdc.umd.js`). The source lives
+in the `mbo.prestashop.com` repo.
 
-### API clients
+`ps_mbo` injects this bundle into the PS back-office via hook templates
+(Smarty `.tpl` files in `views/templates/hook/`). `HaveCdcComponent::smartyDisplayTpl()`
+is the shared rendering method; it assigns a Symfony-generated error URL
+(`admin_mbo_module_cdc_error` route) before delegating to Smarty.
 
-- `src/Distribution/` - MBO API (BaseClient -> ConnectedClient/Client)
-- `src/Addons/ApiClient.php` - Addons catalog API
+Hooks that inject CDC content:
+- `hookDashboardZoneOne`: module catalog page (main zone)
+- `hookDashboardZoneThree`: module catalog page (secondary zone)
+- `hookDisplayAdminThemesListAfter`: theme catalog
 
-### Module collection
+### Remote API endpoint
 
-`src/Module/` - Collection, Builder, Filters, Repository pattern for module lists
-returned to the front-office hooks.
+`controllers/admin/apiPsMbo.php` is a legacy-style PS controller that the MBO
+back-end calls to manage modules on the merchant's shop. Security relies on
+HMAC signature verification (action + module + admin token + action UUID,
+signed with a public key retrieved from the Distribution API). The
+`apiSecurityPsMbo.php` controller handles key rotation.
+
+`src/Api/` contains:
+- `Controller/AbstractAdminApiController.php`: base class with signature
+  validation, CORS handling, JSON response helpers
+- `Service/ModuleTransitionExecutor.php`: executes install/upgrade/uninstall
+  transitions using Symfony Workflow
+- `Service/ConfigApplyExecutor.php`: applies remote config changes
+- `Service/Factory.php`: resolves which executor to invoke from `?service=` param
+
+### Module lifecycle (install/upgrade from Addons)
+
+`hookActionBeforeInstallModule` / `hookActionBeforeUpgradeModule` intercept PS
+module manager operations and download the zip from Addons before the native
+install runs:
+
+```
+hook -> ActionsManager::install(moduleId)
+          -> FilesManager (download zip from Addons API)
+          -> native PS install picks up the local zip
+```
+
+Symfony Workflow (`symfony/workflow`) models the allowed transitions between
+module states (installed, enabled, upgraded, etc.).
+
+### Module collection / catalogue
+
+`src/Module/` provides the data layer for the hook that enriches the module list:
+- `Repository`: queries the local PS module database
+- `CollectionFactory` + `Collection`: builds typed module lists
+- `FiltersFactory` + `Filters`: filtering by status/category
+- `ModuleBuilder`: constructs `Module` VO from raw PS data
+- `Module` VO wraps the legacy `\Module` instance with a `ParameterBag`
+
+### Distribution API clients
+
+Two clients in `src/Distribution/`, both extending `BaseClient` (Guzzle + PSR-18):
+
+| Class | Auth | Use |
+|-------|------|-----|
+| `Client` | anonymous | public key rotation, event tracking |
+| `ConnectedClient` | Accounts JWT + Addons credentials | authenticated module catalogue |
+
+The `accounts_token` query parameter carries the PS Accounts JWT for authenticated
+Distribution API calls. Shops without a linked Accounts are served by `Client`.
+
+### Addons API client
+
+`src/Addons/ApiClient.php` handles zip downloads from
+`https://api-addons.prestashop.com`. Used by `ActionsManager` when resolving
+module sources before install/upgrade.
+
+### Symfony routes
+
+All routes prefixed under `/mbo/`:
+
+| Prefix | Controller | Purpose |
+|--------|-----------|---------|
+| `/mbo/modules/catalog` | `ModuleCatalogController` | module catalog page/AJAX |
+| `/mbo/modules/recommended` | `ModuleRecommendedController` | recommended modules panel |
+| `/mbo/themes/catalog` | `ThemeCatalogController` | theme catalog |
+| `/mbo/addons` | `AddonsController` | Addons-specific routes |
+
+### Service container
+
+Symfony DI defined in `config/services/` (YAML files + one `addons.php` for
+Addons-related services). `src/DependencyInjection/ContainerProvider.php`
+exposes the Symfony container to legacy PS code via `$this->get(ServiceClass::class)`.
+All services must be `public: true` for legacy compatibility.
+
+### Views
+
+- `views/templates/hook/*.tpl` - Smarty: CDC injection, recommended modules,
+  empty category messages
+- `views/templates/admin/` - Twig: error page, AJAX layout (used by Symfony
+  controllers)
+
+## Environment Variables
+
+Defined in `.env` (sourced from GCP Secret Manager in CI); see `.env.dist` for
+defaults:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MBO_CDC_URL` | `https://assets.prestashop3.com/dst/mbo/v1/mbo-cdc.umd.js` | CDC JS bundle URL |
+| `DISTRIBUTION_API_URL` | `https://mbo-api.prestashop.com` | MBO distribution API |
+| `ADDONS_API_URL` | `https://api-addons.prestashop.com` | Addons zip download API |
+| `SENTRY_CREDENTIALS` | (DSN) | Error monitoring |
+| `SENTRY_ENVIRONMENT` | `production` | Sentry env tag |
 
 ## Key Commands
 
 ```bash
-composer install          # install dependencies
+composer install          # install all dependencies (dev included)
+composer install --no-dev -o  # production install
 composer test             # run PHPUnit
-composer lint             # php-cs-fixer (dry-run)
-make build-zip            # local zip (dev)
+composer lint             # php-cs-fixer (dry-run diff)
+make build-zip            # local zip without dev artifacts
 ```
 
 ## Conventions
 
 - PSR-12, `declare(strict_types=1)` at top of every file
-- Each hook = one trait in `src/Traits/Hooks/`; boot logic via `bootXxx()` pattern
-- Service aliases must be `public: true` (legacy PS compatibility)
-- No overrides; hooks only
-- `HaveConfigurationPage.php` is deleted from the production zip by CI: keep
-  production-facing code out of that file
+- One hook = one trait in `src/Traits/Hooks/`; boot logic in `boot{TraitName}()`
+- All services `public: true` in DI config (PS legacy DI constraint)
+- No class overrides; hooks only
+- `HaveConfigurationPage.php` is deleted from production zips by CI and its
+  `use` statement is stripped from `ps_mbo.php` via `sed`; do not put
+  production-facing logic in that file
 
 ## CI / Artifacts
 
-- `build-release.yml` - builds zip, uploads to GCS (preprod) or GitHub release (prod)
-- `php.yml` - linter, cs-fixer, phpstan, phpunit
-- `translations.yml` - Crowdin sync
-- AI context files (`.ai-tools/`, `.claude/`, `CLAUDE.md`) are excluded from
-  all production zip artifacts
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `build-release.yml` | push/PR/release | builds composer, creates zip, uploads to GCS (preprod) or GitHub release (prod) |
+| `php.yml` | PR | php-linter, php-cs-fixer, phpstan, phpunit |
+| `translations.yml` | push to master | Crowdin sync |
+| `install-mydemoshop.yml` | manual | test install on a live demo shop |
+
+AI context files (`.ai-tools/`, `.claude/`, `CLAUDE.md`) are excluded from
+all zip artifacts by CI and `make build-zip`.
 
 ## Points of Attention
 
-- The Sentry transport is blocking by default in PHP-FPM; see `src/Handler/` for
-  the non-blocking override (recent fix: 528fe3a5)
-- `ConnectedClient` requires a valid Accounts token; unauthenticated shops fall
-  back to `Client`
-- PHPStan config lives in `tests/phpstan/`; custom bootstrap in `tests/bootstrap.php`
+- The CDC URL is injected at runtime from the `.env` file; if the CDC JS
+  fails to load, `admin_mbo_module_cdc_error` renders a graceful fallback page
+- `ConnectedClient` requires a valid PS Accounts token; anonymous shops silently
+  fall back to `Client` (limited catalogue, no purchase history)
+- PHPStan config is in `tests/phpstan/`; baseline and custom rules live there
+- The HMAC signature in `apiPsMbo.php` includes `admin_token` (a PS back-office
+  token, not an Accounts token): this is separate from the Accounts JWT used for
+  the Distribution API

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,10 @@
    `mbo.prestashop.com` that renders the full Addons marketplace inside the PS
    back-office (module catalog, theme catalog, recommended modules).
 2. **Addons bridge**: acts as the intermediary between the shop and the Addons
-   platform for everything module-lifecycle related: surfacing available updates
-   in the module manager, intercepting install/upgrade requests to download zips
-   directly from Addons (`AddonsUrlSourceHandler` + `hookActionBeforeInstallModule`
-   / `hookActionBeforeUpgradeModule`), and enriching module lists with catalogue
-   metadata from the Distribution API.
+   platform for everything module-lifecycle related: intercepting install/upgrade
+   requests to download zips directly from Addons (`AddonsUrlSourceHandler` +
+   `hookActionBeforeInstallModule` / `hookActionBeforeUpgradeModule`), and
+   enriching module lists with catalogue metadata from the Distribution API.
 
 Ecosystem map: `.ai-tools/ECOSYSTEM_CONTEXT.md`
 
@@ -65,8 +64,7 @@ service initialization without a monolithic `__construct`.
 
 The Addons catalog UI is **not** built in this repo. It is a compiled JS bundle
 (`mbo-cdc.umd.js`) hosted on the MBO CDN (`MBO_CDC_URL` env var, default:
-`https://assets.prestashop3.com/dst/mbo/v1/mbo-cdc.umd.js`). The source lives
-in the `mbo.prestashop.com` repo.
+`https://assets.prestashop3.com/dst/mbo/v1/mbo-cdc.umd.js`).
 
 `ps_mbo` injects this bundle into the PS back-office via hook templates
 (Smarty `.tpl` files in `views/templates/hook/`). `HaveCdcComponent::smartyDisplayTpl()`
@@ -106,7 +104,7 @@ ModuleManager::install($name, $source)
   hookActionBeforeInstallModule fires but does nothing (source already resolved)
 ```
 
-**Path B - no source (module name only, e.g. from the module manager UI):**
+**Path B - no source (module name only):**
 ```
 ModuleManager::install($name, source=null)
   -> no SourceHandler invoked
@@ -158,7 +156,7 @@ All routes prefixed under `/mbo/`:
 
 | Prefix | Controller | Purpose |
 |--------|-----------|---------|
-| `/mbo/modules/catalog` | `ModuleCatalogController` | module catalog page/AJAX |
+| `/mbo/modules/catalog` | `ModuleCatalogController` | module catalog |
 | `/mbo/modules/recommended` | `ModuleRecommendedController` | recommended modules panel |
 | `/mbo/themes/catalog` | `ThemeCatalogController` | theme catalog |
 | `/mbo/addons` | `AddonsController` | Addons-specific routes |
@@ -227,7 +225,7 @@ all zip artifacts by CI and `make build-zip`.
 - The CDC URL is injected at runtime from the `.env` file; if the CDC JS
   fails to load, `admin_mbo_module_cdc_error` renders a graceful fallback page
 - `ConnectedClient` requires a valid PS Accounts token; anonymous shops silently
-  fall back to `Client` (limited catalogue, no purchase history)
+  fall back to `Client`
 - PHPStan config is in `tests/phpstan/`; baseline and custom rules live there
 - `apiPsMbo.php` and `src/Api/` are legacy v8 code (remote management API,
   removed in v9); do not extend or rely on them

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# ps_mbo - AI Developer Context
+
+## Role in the Ecosystem
+
+PrestaShop module (Back-Office) that surfaces the Addons catalog, manages module
+installation/upgrade lifecycles, and integrates with PrestaShop Accounts, the
+MBO distribution API, and the Addons API.
+
+Ecosystem map: `.ai-tools/ECOSYSTEM_CONTEXT.md`
+
+Key upstream/downstream:
+- `mbo.prestashop.com` feeds module data to this module (Distribution API)
+- `ps_mbo` downloads zip artifacts from `addons.prestashop.com`
+- Accounts integration via `prestashop/prestashop-accounts-installer`
+
+## Stack
+
+- PHP 8.1+, strict_types everywhere
+- PrestaShop 8.x / 9.x (entry guard: `version_compare(_PS_VERSION_, '8.0.2', '<')`)
+- Symfony 6.4 (DI container, Workflow, String)
+- PHPUnit 9.x, PHP-CS-Fixer 3.x, PHPStan 1.x
+
+## Architecture
+
+### Main class composition
+
+`ps_mbo.php` extends `Module` and composes behaviour via three traits:
+
+```
+ps_mbo
+  UseHooks              - registers/dispatches all PS hooks
+    Hooks\UseXxx...     - one file per hook in src/Traits/Hooks/
+  HaveTabs              - admin tab registration
+  HaveConfigurationPage - admin config page (stripped from production builds)
+```
+
+Each PS hook lives in its own trait file (`src/Traits/Hooks/UseXxxHook.php`).
+`UseHooks::bootHooks()` calls `bootXxx()` on each trait at module init.
+
+### Service layer
+
+Symfony container defined in `config/services/` (YAML + one PHP file for Addons).
+`src/DependencyInjection/ContainerProvider.php` exposes the container to
+legacy PS code.
+
+### API clients
+
+- `src/Distribution/` - MBO API (BaseClient -> ConnectedClient/Client)
+- `src/Addons/ApiClient.php` - Addons catalog API
+
+### Module collection
+
+`src/Module/` - Collection, Builder, Filters, Repository pattern for module lists
+returned to the front-office hooks.
+
+## Key Commands
+
+```bash
+composer install          # install dependencies
+composer test             # run PHPUnit
+composer lint             # php-cs-fixer (dry-run)
+make build-zip            # local zip (dev)
+```
+
+## Conventions
+
+- PSR-12, `declare(strict_types=1)` at top of every file
+- Each hook = one trait in `src/Traits/Hooks/`; boot logic via `bootXxx()` pattern
+- Service aliases must be `public: true` (legacy PS compatibility)
+- No overrides; hooks only
+- `HaveConfigurationPage.php` is deleted from the production zip by CI: keep
+  production-facing code out of that file
+
+## CI / Artifacts
+
+- `build-release.yml` - builds zip, uploads to GCS (preprod) or GitHub release (prod)
+- `php.yml` - linter, cs-fixer, phpstan, phpunit
+- `translations.yml` - Crowdin sync
+- AI context files (`.ai-tools/`, `.claude/`, `CLAUDE.md`) are excluded from
+  all production zip artifacts
+
+## Points of Attention
+
+- The Sentry transport is blocking by default in PHP-FPM; see `src/Handler/` for
+  the non-blocking override (recent fix: 528fe3a5)
+- `ConnectedClient` requires a valid Accounts token; unauthenticated shops fall
+  back to `Client`
+- PHPStan config lives in `tests/phpstan/`; custom bootstrap in `tests/bootstrap.php`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,15 +7,17 @@
 1. **Addons catalog UI**: injects a Cross Domain Component (CDC) served by
    `mbo.prestashop.com` that renders the full Addons marketplace inside the PS
    back-office (module catalog, theme catalog, recommended modules).
-2. **Remote module management**: exposes a signed HTTP API so that the MBO
-   back-end (`mbo.prestashop.com`) can remotely trigger module
-   install/upgrade/uninstall actions on a merchant shop.
+2. **Addons bridge**: acts as the intermediary between the shop and the Addons
+   platform for everything module-lifecycle related: surfacing available updates
+   in the module manager, intercepting install/upgrade requests to download zips
+   directly from Addons (`AddonsUrlSourceHandler` + `hookActionBeforeInstallModule`
+   / `hookActionBeforeUpgradeModule`), and enriching module lists with catalogue
+   metadata from the Distribution API.
 
 Ecosystem map: `.ai-tools/ECOSYSTEM_CONTEXT.md`
 
 Key upstream/downstream:
-- `mbo.prestashop.com` -> `ps_mbo`: serves the CDC JS bundle and calls the
-  remote API endpoint to manage modules
+- `mbo.prestashop.com` -> `ps_mbo`: serves the CDC JS bundle
 - `ps_mbo` -> Distribution API (`https://mbo-api.prestashop.com`): fetches
   module catalogue data (authenticated and anonymous)
 - `ps_mbo` -> Addons API (`https://api-addons.prestashop.com`): downloads
@@ -76,33 +78,34 @@ Hooks that inject CDC content:
 - `hookDashboardZoneThree`: module catalog page (secondary zone)
 - `hookDisplayAdminThemesListAfter`: theme catalog
 
-### Remote API endpoint
+### Legacy API controllers (v8 remnants)
 
-`controllers/admin/apiPsMbo.php` is a legacy-style PS controller that the MBO
-back-end calls to manage modules on the merchant's shop. Security relies on
-HMAC signature verification (action + module + admin token + action UUID,
-signed with a public key retrieved from the Distribution API). The
-`apiSecurityPsMbo.php` controller handles key rotation.
+`controllers/admin/apiPsMbo.php` and `apiSecurityPsMbo.php` are legacy-style PS
+controllers that implemented a signed remote management API in PS8 (allowed the
+MBO back-end to trigger module actions on the shop). This mechanism was removed
+in PS9 and these files are vestigial. Do not build on them.
 
-`src/Api/` contains:
-- `Controller/AbstractAdminApiController.php`: base class with signature
-  validation, CORS handling, JSON response helpers
-- `Service/ModuleTransitionExecutor.php`: executes install/upgrade/uninstall
-  transitions using Symfony Workflow
-- `Service/ConfigApplyExecutor.php`: applies remote config changes
-- `Service/Factory.php`: resolves which executor to invoke from `?service=` param
+`src/Api/` contains the supporting infrastructure (HMAC signature verification,
+`AbstractAdminApiController`, `ModuleTransitionExecutor`, `ConfigApplyExecutor`)
+that powered this feature. Treat as read-only legacy code.
 
 ### Module lifecycle (install/upgrade from Addons)
 
-`hookActionBeforeInstallModule` / `hookActionBeforeUpgradeModule` intercept PS
-module manager operations and download the zip from Addons before the native
-install runs:
+`ps_mbo` intercepts the native PS module manager install and upgrade flows to
+download zips from Addons transparently:
 
 ```
-hook -> ActionsManager::install(moduleId)
-          -> FilesManager (download zip from Addons API)
-          -> native PS install picks up the local zip
+PS module manager install/upgrade
+  -> hookActionBeforeInstallModule / hookActionBeforeUpgradeModule
+       -> ActionsManager::install(moduleId)
+            -> AddonsUrlSourceHandler::handle(addonsUrl)
+                 -> AddonsUrlSourceRetriever (downloads zip from Addons API)
+                 -> ZipSourceHandler (hands zip to PS native installer)
 ```
+
+`src/Module/SourceHandler/AddonsUrlSourceHandler.php` implements PS's
+`SourceHandlerInterface`, so it integrates seamlessly with the module manager's
+source resolution pipeline.
 
 Symfony Workflow (`symfony/workflow`) models the allowed transitions between
 module states (installed, enabled, upgraded, etc.).
@@ -211,6 +214,5 @@ all zip artifacts by CI and `make build-zip`.
 - `ConnectedClient` requires a valid PS Accounts token; anonymous shops silently
   fall back to `Client` (limited catalogue, no purchase history)
 - PHPStan config is in `tests/phpstan/`; baseline and custom rules live there
-- The HMAC signature in `apiPsMbo.php` includes `admin_token` (a PS back-office
-  token, not an Accounts token): this is separate from the Accounts JWT used for
-  the Distribution API
+- `apiPsMbo.php` and `src/Api/` are legacy v8 code (remote management API,
+  removed in v9); do not extend or rely on them

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,18 +94,34 @@ that powered this feature. Treat as read-only legacy code.
 `ps_mbo` intercepts the native PS module manager install and upgrade flows to
 download zips from Addons transparently:
 
+Two distinct paths depending on whether a `$source` is provided to `ModuleManager`:
+
+**Path A - source provided (e.g. Addons URL):**
 ```
-PS module manager install/upgrade
-  -> hookActionBeforeInstallModule / hookActionBeforeUpgradeModule
-       -> ActionsManager::install(moduleId)
-            -> AddonsUrlSourceHandler::handle(addonsUrl)
-                 -> AddonsUrlSourceRetriever (downloads zip from Addons API)
-                 -> ZipSourceHandler (hands zip to PS native installer)
+ModuleManager::install($name, $source)
+  -> sourceFactory->getHandler($source)   // PS Core
+       -> AddonsUrlSourceHandler::canHandle($source) == true
+            -> AddonsUrlSourceRetriever::get($source)  (downloads zip)
+            -> ZipSourceHandler::handle($localZipPath)
+  hookActionBeforeInstallModule fires but does nothing (source already resolved)
 ```
 
-`src/Module/SourceHandler/AddonsUrlSourceHandler.php` implements PS's
-`SourceHandlerInterface`, so it integrates seamlessly with the module manager's
-source resolution pipeline.
+**Path B - no source (module name only, e.g. from the module manager UI):**
+```
+ModuleManager::install($name, source=null)
+  -> no SourceHandler invoked
+  -> hookActionBeforeInstallModule fires
+       -> ActionsManager::install(moduleId)
+            -> Addons API download by module ID
+            -> native PS installer picks up the local zip
+```
+
+`AddonsUrlSourceHandler` (`src/Module/SourceHandler/`) implements PS Core's
+`SourceHandlerInterface` and is registered in the DI container so the source
+factory picks it up automatically when the caller provides an Addons URL.
+
+The hook is therefore a fallback: it covers call sites that don't pass a source
+(e.g. back-office module manager triggered by name).
 
 Symfony Workflow (`symfony/workflow`) models the allowed transitions between
 module states (installed, enabled, upgraded, etc.).

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ build-zip:
 	rm -rf /tmp/ps_mbo/.editorconfig
 	rm -rf /tmp/ps_mbo/.git
 	rm -rf /tmp/ps_mbo/.github
+	rm -rf /tmp/ps_mbo/.ai-tools
+	rm -rf /tmp/ps_mbo/.claude
+	rm -rf /tmp/ps_mbo/CLAUDE.md
 	rm -rf /tmp/ps_mbo/_dev
 	rm -rf /tmp/ps_mbo/tests
 	rm -rf /tmp/ps_mbo/docker-compose.yml


### PR DESCRIPTION
## Summary

- Add `marketplace-ai-tools` as git submodule at `.ai-tools/` (points to `main`)
- Create `CLAUDE.md` at root with project architecture, conventions, and ecosystem context
- Add `.gitattributes` with `export-ignore` for all AI context paths
- Exclude `.ai-tools/`, `.claude/`, `CLAUDE.md` from zip artifacts in `build-release.yml` (preprod + prod jobs) and `Makefile`

Closes SM-380

## Test plan

- [ ] CI php.yml passes (no PHP files touched)
- [ ] Submodule `.ai-tools/` resolves to `PrestaShopCorp/marketplace-ai-tools@main`
- [ ] Production zip does not contain `.ai-tools/`, `.claude/`, or `CLAUDE.md`
- [ ] `CLAUDE.md` content aligns with `.ai-tools/ECOSYSTEM_CONTEXT.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)