### PR TITLE
fix: backport Sentry fixes to 4.x (env var rename + http_timeout)

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,7 +1,7 @@
 MBO_CDC_URL="http://localhost:8080/dist/mbo-cdc.umd.js"
 DISTRIBUTION_API_URL="http://localhost:3000"
-SENTRY_CREDENTIALS=""
-SENTRY_ENVIRONMENT=""
+PS_MBO_SENTRY_CREDENTIALS=""
+PS_MBO_SENTRY_ENVIRONMENT=""
 ADDONS_API_URL="https://api-addons.prestashop.com"
 
 # For testing purpose only

--- a/src/Handler/ErrorHandler/ErrorHandler.php
+++ b/src/Handler/ErrorHandler/ErrorHandler.php
@@ -46,7 +46,7 @@ class ErrorHandler implements ErrorHandlerInterface
 
     public function __construct()
     {
-        $this->dsn = getenv('SENTRY_CREDENTIALS');
+        $this->dsn = getenv('PS_MBO_SENTRY_CREDENTIALS');
 
         if (empty($this->dsn)) {
             return;
@@ -56,9 +56,11 @@ class ErrorHandler implements ErrorHandlerInterface
             \Sentry\init([
                 'dsn' => $this->dsn,
                 'release' => \ps_mbo::VERSION,
-                'environment' => getenv('SENTRY_ENVIRONMENT'),
+                'environment' => getenv('PS_MBO_SENTRY_ENVIRONMENT'),
                 'traces_sample_rate' => 0.5,
                 'sample_rate' => 0.5,
+                'http_timeout' => 2,
+                'http_connect_timeout' => 1,
             ]);
 
             \Sentry\configureScope(function (Scope $scope): void {

--- a/src/Traits/HaveConfigurationPage.php
+++ b/src/Traits/HaveConfigurationPage.php
@@ -146,9 +146,9 @@ trait HaveConfigurationPage
         $envData = preg_replace('#MBO_CDC_URL=".*"#', 'MBO_CDC_URL="' . $cdcUrl . '"', $envData);
         $envData = preg_replace('#DISTRIBUTION_API_URL=".*"#', 'DISTRIBUTION_API_URL="' . $apiUrl . '"', $envData);
         $envData = preg_replace('#ADDONS_API_URL=".*"#', 'ADDONS_API_URL="' . $addonsUrl . '"', $envData);
-        $envData = preg_replace('#SENTRY_CREDENTIALS=".*"#', 'SENTRY_CREDENTIALS="' . $sentryUrl . '"', $envData);
+        $envData = preg_replace('#PS_MBO_SENTRY_CREDENTIALS=".*"#', 'PS_MBO_SENTRY_CREDENTIALS="' . $sentryUrl . '"', $envData);
         $envData =
-            preg_replace('#SENTRY_ENVIRONMENT=".*"#', 'SENTRY_ENVIRONMENT="' . $sentryEnvironment . '"', $envData);
+            preg_replace('#PS_MBO_SENTRY_ENVIRONMENT=".*"#', 'PS_MBO_SENTRY_ENVIRONMENT="' . $sentryEnvironment . '"', $envData);
 
         // Update the .env file
         file_put_contents($envFilePath, $envData);


### PR DESCRIPTION
## Summary

Backport of PRs #867 and #866 from master to 4.x.

- Rename `SENTRY_CREDENTIALS` -> `PS_MBO_SENTRY_CREDENTIALS` and `SENTRY_ENVIRONMENT` -> `PS_MBO_SENTRY_ENVIRONMENT` to avoid conflicts with other modules sharing the same `.env` on multi-module servers
- Add `http_timeout=2` and `http_connect_timeout=1` to `\Sentry\init()` to prevent PHP-FPM workers from blocking indefinitely when Sentry is slow or quota-exceeded (observed in production: workers stalling 5-30s during quota-exceeded periods)

**Note:** Manual adaptation vs master - 4.x uses `getenv()` directly instead of `EnvHelper::getEnv()`.

## Files changed

- `src/Handler/ErrorHandler/ErrorHandler.php`: env var rename + http timeouts
- `src/Traits/HaveConfigurationPage.php`: preg_replace patterns updated
- `.env.dist`: variable names updated

## Test plan

- [ ] Deploy to staging and verify Sentry still initializes with the new var names
- [ ] Verify that `SENTRY_CREDENTIALS` from another module's `.env` is no longer picked up by ps_mbo
- [ ] Confirm PHP-FPM workers are no longer blocked on Sentry captures

🤖 Generated with [Claude Code](https://claude.com/claude-code)