### PR TITLE
chore: bump GitHub Actions versions in CI/CD workflows (backport to 4.x)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: 'actions/checkout@v4'
+        uses: 'actions/checkout@v6'
         with:
           path: ''
 
@@ -30,7 +30,7 @@ jobs:
         uses: 'PrestaShopCorp/github-action-clean-before-deploy@v2.0'
 
       - name: Cache module folder
-        uses: 'actions/cache@v4'
+        uses: 'actions/cache@v5'
         with:
           path: ./
           key: ${{ github.run_id }}
@@ -46,7 +46,7 @@ jobs:
 
       - name: Retrieve from cache module folder
         id: retrieve-cache
-        uses: 'actions/cache@v4'
+        uses: 'actions/cache@v5'
         with:
           path: ./
           key: ${{ github.run_id }}
@@ -99,7 +99,7 @@ jobs:
 
       - name: Retrieve from cache module folder
         id: retrieve-cache
-        uses: 'actions/cache@v4'
+        uses: 'actions/cache@v5'
         with:
           path: ./
           key: ${{ github.run_id }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: PHP syntax checker 7.2
         uses: prestashop/github-action-php-lint/7.2@master
       - name: PHP syntax checker 7.3
@@ -28,7 +28,7 @@ jobs:
       PHP_VERSION: '7.4'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Composer Install
         run: COMPOSER_PROCESS_TIMEOUT=600 composer install --ansi --prefer-dist --no-interaction --no-progress
       - name: Wait for services to be ready
@@ -52,14 +52,14 @@ jobs:
       - name: Wait for container to be loaded
         run: sleep 10
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Cache vendor folder
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: vendor
           key: php-${{ hashFiles('composer.lock') }}
       - name: Cache composer folder
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.composer/cache
           key: php-composer-cache
@@ -79,18 +79,18 @@ jobs:
           coverage: xdebug
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Add vendor folder in cache to make next builds faster
       - name: Cache vendor folder
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: vendor
           key: php-${{ hashFiles('composer.lock') }}
 
       # Add composer local folder in cache to make next builds faster
       - name: Cache composer folder
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.composer/cache
           key: php-composer-cache

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -10,7 +10,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'translations_update')
     steps:
       - name: Checkout module-translation-tool
-        uses: actions/checkout@v2.0.0
+        uses: actions/checkout@v6
         with:
           repository: PrestaShopCorp/module-translation-tool
           ref: main


### PR DESCRIPTION
## Summary

Backport of PR #868 from master to 4.x.

- `actions/checkout`: v2/v4 -> v6 (3 workflow files)
- `actions/cache`: v4 -> v5 (2 workflow files)

## Test plan

- [ ] CI php.yml passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)