### PR TITLE
chore: set up AI developer context for 4.x branch

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,68 @@
+---
+name: code-reviewer
+description: Reviews PHP/PrestaShop code changes for correctness, security, and compliance with ps_mbo 4.x conventions. Use for PRs, feature branches, or any diff review.
+tools: Read, Grep, Glob, Bash
+memory: project
+---
+
+You are a senior PHP engineer specializing in PrestaShop module development. You review code for the `ps_mbo` module, branch 4.x.
+
+## Project context
+
+- PHP >=7.2.5, `declare(strict_types=1)` required in every file
+- PSR-12 code style
+- PrestaShop 8.x compatibility (entry guard: `version_compare(_PS_VERSION_, '8.0.2', '<')`)
+- Symfony 5.x DI container: all services must be `public: true`
+- One hook = one trait in `src/Traits/Hooks/`; boot logic in `boot{TraitName}()`
+- No class overrides — hooks only
+- `HaveConfigurationPage` is stripped in production builds; never put production logic there
+- `src/Api/` and `controllers/admin/apiPsMbo.php` / `apiSecurityPsMbo.php` implement the **active** remote management API (HMAC-signed calls from mbo.prestashop.com). This is live code, not vestigial — do not suggest removing it.
+- Tab system (`src/Tab/`) is active and manages PS back-office tabs registration
+
+## Review checklist
+
+### Correctness
+- Logic errors, off-by-one, null/undefined handling
+- Edge cases for both authenticated (ConnectedClient) and anonymous (Client) shops
+- Proper hook return values (some hooks expect specific types or null)
+- Remote management API: HMAC signature verification must remain intact
+
+### Security
+- No SQL injection (use PS `Db::getInstance()->escape()` or Doctrine)
+- No XSS (escape output in Twig with `| escape` / in Smarty with `{$var|escape}`)
+- No hardcoded credentials or API keys
+- Guzzle requests: verify TLS is not disabled, no user-controlled URLs without validation
+- Remote management API: never weaken HMAC verification or admin session handling
+
+### PrestaShop conventions
+- `declare(strict_types=1)` at top of every PHP file
+- PSR-12 formatting
+- Hook traits: each has its own file, boot method follows `boot{TraitName}()` naming
+- DI services: `public: true` in YAML config
+- Environment-dependent values come from `.env` / container parameters, never hardcoded
+
+### Architecture
+- New functionality goes through Symfony services, not procedural code in the main class
+- Distribution API calls use `Client` (anonymous) or `ConnectedClient` (authenticated) — not raw Guzzle
+- Module source resolution uses `SourceHandlerInterface` pattern, not direct download calls
+- Tab registration goes through `src/Tab/` collection, not direct PS tab API calls
+
+### Tests
+- PHPUnit 8.x/9.x conventions
+- New logic has test coverage
+- No test bypasses (`@covers` on wrong class, untested public methods in non-trivial classes)
+
+## Output format
+
+Structure your review as:
+
+**Summary**: one sentence on the overall quality.
+
+**Findings**: grouped by severity — Critical, Major, Minor, Nit. Each finding:
+- Location (file:line)
+- What the problem is
+- Concrete fix (code snippet when relevant)
+
+**Positives**: note patterns done well, especially if they correct a past anti-pattern.
+
+If there is nothing to flag in a category, omit it. Be direct; do not pad the review.

--- a/.claude/rules/di-config.md
+++ b/.claude/rules/di-config.md
@@ -1,0 +1,53 @@
+---
+paths:
+  - "config/services/**/*.yml"
+  - "config/services/**/*.yaml"
+  - "config/services/**/*.php"
+---
+
+# Symfony DI configuration conventions
+
+## Public services
+
+All services must be reachable via `$this->get()` from legacy PS code. The `_defaults` block already sets `public: true` in each YAML file — do not remove it, and do not set `public: false` on individual services.
+
+## Environment variables
+
+API base URLs and credentials must come from env vars:
+
+```yaml
+arguments:
+  $apiUrl: "%env(DISTRIBUTION_API_URL)%"
+```
+
+Never hardcode any URL directly in YAML.
+
+## Autowire
+
+- Use `autowire: true` only when constructor arguments can be resolved unambiguously from type hints
+- If a service needs explicit `$apiUrl`, `$httpClient`, or other non-typed scalar args, list them under `arguments:` explicitly
+- Do not mix `autowire: true` with a full `arguments:` block — pick one approach
+
+## Factory pattern
+
+For services built via a static factory method (e.g. Doctrine cache wrappers):
+
+```yaml
+factory: [ ClassName, staticMethodName ]
+arguments:
+  $pool: '@DependencyServiceId'
+```
+
+## File ownership
+
+| File | Owns |
+|------|------|
+| `distribution.yml` | Distribution API clients and cache |
+| `addons.yml` / `addons.php` | Addons API client and source handler |
+| `accounts.yml` | ps_accounts integration services |
+| `cdc.yml` | CDC context builder and related services |
+| `modules.yml` | Module collection, repository, builder |
+| `security.yml` | HMAC verifier and remote management API security |
+| `tab.yml` | PS tab registration services |
+
+Add new services to the file that owns their domain; do not dump everything into a catch-all file.

--- a/.claude/rules/hook-traits.md
+++ b/.claude/rules/hook-traits.md
@@ -1,0 +1,76 @@
+---
+paths:
+  - "src/Traits/Hooks/*.php"
+  - "src/Traits/*.php"
+---
+
+# Hook trait conventions
+
+## File structure
+
+Every hook trait must follow this order:
+1. License header (AFL 3.0 block comment)
+2. `declare(strict_types=1);`
+3. `namespace PrestaShop\Module\Mbo\Traits\Hooks;`
+4. `use` statements
+5. `if (!defined('_PS_VERSION_')) { exit; }`
+6. `trait Use{HookName}`
+
+## Service access
+
+- Always retrieve services via `$this->get(ServiceClass::class)`, never via `new`
+- After `$this->get()`, check for `null` and throw `ExpectedServiceNotFoundException` if required
+- Wrap service retrieval in try/catch; on exception call `ErrorHelper::reportError($e)` then return `''` (not `false`)
+
+## Hook return types
+
+- Display hooks (`hookDisplay*`, `hookDashboard*`): return type `false|string`, return `''` on error (not `false`)
+- Action hooks (`hookAction*`): typically `void` or `array`; document expected shape if array
+
+## NEVER let an exception escape a hook
+
+A hook is called inside a PrestaShop workflow (module install, page render, module list build...). An uncaught exception propagates up and breaks the entire workflow for the merchant, not just this module.
+
+**Every hook method must be wrapped in a top-level try/catch(\Throwable).** No exception — checked or unchecked — may bubble out.
+
+```php
+// WRONG — exception escapes, breaks the PS workflow
+public function hookActionListModules(array $params): array
+{
+    $service = $this->get(MyService::class); // throws if container not ready
+    return $service->enrich($params['list']);
+}
+
+// CORRECT
+public function hookActionListModules(array $params): array
+{
+    try {
+        $service = $this->get(MyService::class);
+        if (null === $service) {
+            throw new ExpectedServiceNotFoundException('...');
+        }
+        return $service->enrich($params['list']);
+    } catch (\Throwable $e) {
+        ErrorHelper::reportError($e);
+        return [];
+    }
+}
+```
+
+Return a safe neutral value on failure: `''` for display hooks, `[]` for hooks returning arrays, the unmodified input for hooks enriching a list.
+
+## Boot method
+
+Each trait must have a `boot{TraitName}()` method (e.g. `bootUseDashboardZoneOne()`) called by `UseHooks::bootHooks()`. Put any per-hook service initialization here, not in the hook method itself.
+
+## CDC-injecting hooks
+
+Hooks that inject CDC content must call `$this->smartyDisplayTpl()` from `HaveCdcComponent`, not Smarty directly. The `admin_mbo_module_cdc_error` route must be assigned before rendering.
+
+## Active hooks on 4.x (not in v5/master)
+
+These hooks exist on 4.x and are NOT present in v5:
+- `UseActionAdminControllerSetMedia`: injects CSS/JS for the connection toolbar and MBO employee explanation UI
+- `UseActionGetAdminToolbarButtons`: adds MBO-specific buttons to the PS admin toolbar
+- `UseDisplayAdminAfterHeader`: renders the connection toolbar (admin user status, register CTA)
+- `hookDashboardZoneTwo`: secondary CDC zone on the module catalog page

--- a/.claude/rules/templates.md
+++ b/.claude/rules/templates.md
@@ -1,0 +1,32 @@
+---
+paths:
+  - "views/templates/**/*.tpl"
+  - "views/templates/**/*.html.twig"
+---
+
+# Template conventions
+
+## Escaping
+
+- **Smarty**: always escape user-facing output with `{$var|escape:'html':'UTF-8'}` or `{$var|escape}`
+- **Twig**: use `{{ var | e }}` or `{{ var }}` (auto-escape is on); disable with `| raw` only for trusted HTML built server-side
+
+## No logic in templates
+
+Templates must only display data already prepared by the controller or hook method. No service calls, no `Db` queries, no business logic. Move any conditional logic to the PHP side and pass a boolean flag.
+
+## CDC templates (`.tpl` in `hook/`)
+
+- The CDC JS bundle URL comes from the `$mbo_cdc_url` Smarty variable, never hardcoded
+- Do not reference `assets.prestashop3.com` or any CDN URL directly
+- The error fallback URL comes from the `$mbo_error_url` variable set by `HaveCdcComponent::smartyDisplayTpl()`
+
+## Twig admin templates
+
+- Extend `@PrestaShop/Admin/layout.html.twig` for full-page views, or `layout-ajax.html.twig` for AJAX-loaded panels
+- Use `{{ path('route_name') }}` for internal URLs, never string concatenation
+- Translation strings: `{{ 'key'|trans({}, 'Admin.Modules.Feature') }}`
+
+## Asset loading
+
+- JS/CSS assets are registered via the controller's `Media` calls or Smarty `{addjs}`/`{addcss}`, not inline `<script>` or `<style>` tags in templates

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,32 @@
+---
+paths:
+  - "tests/**/*.php"
+---
+
+# Testing conventions
+
+## Framework and base classes
+
+- PHPUnit 8.x/9.x
+- Use `MockeryTestCase` (from `mockery/mockery`) when you need expressive mock expectations; use `createMock()` for simple stubs
+- Workflow tests extend `AbstractTransitionTest` — check it for helper methods before writing boilerplate
+- Namespace mirrors `src/`: `PrestaShop\Module\Mbo\Tests\*`
+
+## Test structure
+
+- `@dataProvider` for all parametrized cases; provider method name must be referenced in the docblock
+- Provider methods return `yield` expressions, not arrays, for readability
+- `setUp()` initializes shared state; each test method is self-contained beyond that
+- `declare(strict_types=1)` is NOT required in test files (unlike `src/`)
+
+## What to test
+
+- Unit tests for pure logic (Filters, Workflow transitions, VO construction)
+- Mock external dependencies (Distribution API clients, PS `Db`, `Module`) — not internal collaborators
+- Do not test the PS framework itself; test the module's own behavior
+
+## Assertions
+
+- `assertEquals` for value equality, `assertSame` when type matters
+- `expectException(FooException::class)` before the call that throws, never in `catch`
+- Avoid `assertTrue(true)` or empty test bodies

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,20 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(composer install)",
+      "Bash(composer install *)",
+      "Bash(composer require *)",
+      "Bash(composer update *)",
+      "Bash(composer remove *)",
+      "Bash(composer dump-autoload *)",
+      "Bash(composer test)",
+      "Bash(composer lint)",
+      "Bash(php -d date.timezone=UTC ./vendor/bin/phpunit *)",
+      "Bash(./vendor/bin/phpunit *)",
+      "Bash(./vendor/bin/phpstan *)",
+      "Bash(./vendor/bin/php-cs-fixer *)",
+      "Bash(make build-zip)",
+      "Bash(make build-zip-prod)"
+    ]
+  }
+}

--- a/.claude/skills/release-versioning/SKILL.md
+++ b/.claude/skills/release-versioning/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: release-versioning
+description: "Version bump + GitHub release workflow for ps_mbo 4.x branch. Analyzes commits since last tag, proposes patch/minor bump, checks hooks for upgrade file need, commits the bump, then creates the GitHub release with auto-generated changelog."
+---
+
+# Release Versioning Workflow (4.x branch)
+
+Use this skill to bump the module version and publish a GitHub release from the 4.x branch.
+
+## Step 1: Ensure clean state on 4.x
+
+```bash
+git checkout 4.x
+git fetch origin
+git pull origin 4.x
+```
+
+If there are uncommitted changes, stop and ask the user to commit or stash them first.
+
+## Step 2: Identify current state
+
+```bash
+git describe --tags --abbrev=0        # e.g. v4.14.1
+git log <last_tag>..HEAD --oneline --no-merges
+```
+
+Also read:
+- `ps_mbo.php`: `const VERSION = '...'` and `$this->version = '...'`
+- `config.xml`: `<version><![CDATA[...]]></version>`
+
+Note the last-tag version (e.g., 4.14.1) and the current file version (may already be bumped).
+
+## Step 3: Analyze commits and propose bump
+
+Scan commit messages since the last tag:
+
+| Commit type | Bump type |
+|-------------|-----------|
+| `feat:` or `feat(...):` | **minor** (4.Y.0) |
+| `BREAKING CHANGE` in body | Refuse major, apply minor and flag it |
+| `fix:`, `chore:`, `refactor:`, `docs:`, `ci:`, `perf:`, `test:` | **patch** (4.x.Z) |
+| No conventional prefix | **patch** (assume patch, flag as ambiguous) |
+
+Highest-priority rule wins: any `feat:` -> propose minor, else -> propose patch.
+
+**Present both options to the user**, pre-selecting the recommended one. Never propose major (no 5.x from this branch).
+
+## Step 4: Check hooks for upgrade file
+
+Detect hook-related changes since the last tag:
+
+```bash
+git diff --name-status <last_tag>..HEAD -- src/Traits/Hooks/
+git diff <last_tag>..HEAD -- ps_mbo.php | grep -E "^\+.*hook|^\-.*hook"
+```
+
+If any hook trait was added or removed, or the hooks list in `ps_mbo.php` changed:
+1. Check if `upgrade/upgrade-<new_version>.php` already exists.
+2. If it does not exist, propose creating it with this template:
+
+```php
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+$rootDir = defined('_PS_ROOT_DIR_') ? _PS_ROOT_DIR_ : getenv('_PS_ROOT_DIR_');
+if (!$rootDir) {
+    $rootDir = __DIR__ . '/../../../';
+}
+
+require_once $rootDir . '/vendor/autoload.php';
+
+/**
+ * @param ps_mbo $module
+ *
+ * @return bool
+ */
+function upgrade_module_<version_underscored>(Module $module): bool
+{
+    $module->updateHooks();
+
+    return true;
+}
+```
+
+Replace `<version_underscored>` with the new version using underscores (e.g., `4_14_2` for version `4.14.2`).
+
+If no hook changes are detected, skip this step silently.
+
+## Step 5: Confirm and apply the bump
+
+Once the user confirms the target version:
+
+**If files already have this version** (detected in Step 2):
+- Say: "Files already at vX.Y.Z (bumped in commit abc1234). No new bump commit needed."
+- Jump to Step 6.
+
+**If files are still on the old version:**
+1. Update `ps_mbo.php`:
+   - `const VERSION = '<new_version>';`
+   - `$this->version = '<new_version>';`
+2. Update `config.xml`:
+   - `<version><![CDATA[<new_version>]]></version>`
+3. Stage and commit (include upgrade file if created in Step 4):
+   ```bash
+   git add ps_mbo.php config.xml
+   git commit -m "chore: bump version <old_version> -> <new_version>"
+   git push origin 4.x
+   ```
+
+If an upgrade file was created but the version bump was already committed separately:
+```bash
+git add upgrade/upgrade-<new_version>.php
+git commit -m "chore: add upgrade script for v<new_version>"
+git push origin 4.x
+```
+
+## Step 6: Create the GitHub release
+
+```bash
+gh release create v<new_version> \
+  --title "v<new_version>" \
+  --generate-notes \
+  --target 4.x
+```
+
+Do NOT add `--latest` — this is a maintenance branch; the latest release remains on master/v5.
+
+Output the release URL.
+
+## Rules
+
+- Never bump major (no 5.x from this branch — that is a separate codebase).
+- Tag format: `v<major>.<minor>.<patch>` (e.g., `v4.14.2`). Release name = tag name.
+- `--generate-notes` uses GitHub's auto-changelog from commits between the previous and new tag.
+- No `--latest` flag: 4.x is a maintenance branch; v5 (master) is the canonical latest.
+- If branch protection prevents direct push to 4.x: use `chore/bump-<new_version>` branch, open PR targeting `4.x`, merge, then run `gh release create` after merge.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Export-ignore: excluded from git archive exports and production artifacts
+.ai-tools/  export-ignore
+.claude/    export-ignore
+CLAUDE.md   export-ignore

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -76,6 +76,10 @@ jobs:
         run: |
           rm -f gha-*.json
 
+      - name: Remove AI context files
+        run: |
+          rm -rf .ai-tools/ .claude/ CLAUDE.md
+
       - name: Prepare the zip
         run: |
           cd ..
@@ -130,6 +134,10 @@ jobs:
           rm -f gha-*.json
           rm -f ./src/Traits/HaveConfigurationPage.php
           sed -i '/HaveConfigurationPage/d' ps_mbo.php
+
+      - name: Remove AI context files
+        run: |
+          rm -rf .ai-tools/ .claude/ CLAUDE.md
 
       - name: Prepare the production zip
         run: |

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -76,9 +76,10 @@ jobs:
         run: |
           rm -f gha-*.json
 
-      - name: Remove AI context files
+      - name: Remove dev-only files
         run: |
           rm -rf .ai-tools/ .claude/ CLAUDE.md
+          rm -f .t9n.yml .gitattributes .gitmodules
 
       - name: Prepare the zip
         run: |
@@ -135,9 +136,10 @@ jobs:
           rm -f ./src/Traits/HaveConfigurationPage.php
           sed -i '/HaveConfigurationPage/d' ps_mbo.php
 
-      - name: Remove AI context files
+      - name: Remove dev-only files
         run: |
           rm -rf .ai-tools/ .claude/ CLAUDE.md
+          rm -f .t9n.yml .gitattributes .gitmodules
 
       - name: Prepare the production zip
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".ai-tools"]
+	path = .ai-tools
+	url = git@github.com:PrestaShopCorp/marketplace-ai-tools.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,274 @@
+# ps_mbo 4.x - AI Developer Context
+
+## Role in the Ecosystem
+
+`ps_mbo` is a PrestaShop back-office module. Its core responsibilities on the 4.x branch:
+
+1. **Addons catalog UI**: injects a Cross Domain Component (CDC) served by
+   `mbo.prestashop.com` that renders the full Addons marketplace inside the PS
+   back-office (module catalog, theme catalog, recommended modules).
+2. **Addons bridge**: acts as the intermediary between the shop and the Addons
+   platform for module lifecycle operations: install/upgrade zip downloads from
+   Addons, and enriching module lists with catalogue metadata from the Distribution API.
+3. **Remote management API**: registers the shop with `mbo.prestashop.com` and
+   exposes HMAC-signed endpoints that allow the MBO back-end to trigger remote
+   actions (module installs, security updates) on the shop. This involves creating
+   and maintaining a persistent MBO admin user on the shop.
+
+Ecosystem map: `.ai-tools/ECOSYSTEM_CONTEXT.md`
+
+Key upstream/downstream:
+- `mbo.prestashop.com` -> `ps_mbo`: serves the CDC JS bundle AND calls HMAC-signed
+  admin endpoints for remote module management
+- `ps_mbo` -> Distribution API (`https://mbo-api.prestashop.com`): fetches
+  module catalogue data (authenticated and anonymous)
+- `ps_mbo` -> Addons API (`https://api-addons.prestashop.com`): downloads
+  module zip files for install/upgrade
+- `ps_mbo` requires `ps_accounts` to be installed; the Accounts JWT token is
+  forwarded to the Distribution API for authenticated calls
+
+## Stack
+
+- PHP >=7.2.5, `declare(strict_types=1)` everywhere
+- PrestaShop 8.x (entry guard: `version_compare(_PS_VERSION_, '8.0.2', '<')`)
+- Symfony 5.x (DI container, Workflow, String components)
+- Guzzle HTTP (via PSR-18 interfaces) for outbound API calls
+- firebase/php-jwt ^6.3 for JWT handling
+- Smarty (hook templates) + Twig (Symfony controller views)
+- PHPUnit 8.x/9.x, PHP-CS-Fixer 3.x, PHPStan 1.x
+
+## Architecture
+
+### Main class composition
+
+`ps_mbo.php` extends PrestaShop's `Module` and composes all behaviour via traits:
+
+```
+ps_mbo
+  UseHooks                           (src/Traits/UseHooks.php)
+    Hooks\UseDashboardZoneOne
+    Hooks\UseDashboardZoneTwo
+    Hooks\UseDashboardZoneThree
+    Hooks\UseDisplayAdminThemesListAfter
+    Hooks\UseDisplayDashboardTop
+    Hooks\UseDisplayAdminAfterHeader     <- connection toolbar (4.x only)
+    Hooks\UseActionAdminControllerSetMedia  <- CSS/JS for toolbar (4.x only)
+    Hooks\UseActionGetAdminToolbarButtons   <- MBO toolbar buttons (4.x only)
+    Hooks\UseActionBeforeInstallModule
+    Hooks\UseActionBeforeUpgradeModule
+    Hooks\UseActionGetAlternativeSearchPanels
+    Hooks\UseActionListModules
+    Hooks\UseDisplayEmptyModuleCategoryExtraMessage
+  HaveTabs              (src/Traits/HaveTabs.php)
+  HaveConfigurationPage (src/Traits/HaveConfigurationPage.php) — dev only
+  HaveCdcComponent      (src/Traits/HaveCdcComponent.php)
+```
+
+Each PS hook lives in its own file under `src/Traits/Hooks/`. `UseHooks::bootHooks()`
+calls `boot{TraitName}()` on each hook trait at module init, allowing per-hook
+service initialization without a monolithic `__construct`.
+
+### Remote Management API (4.x active feature)
+
+`ps_mbo` registers the shop with the MBO back-end (`mbo.prestashop.com`) and
+exposes a remote action API. This allows the MBO team to trigger module operations
+(security patches, forced upgrades) on the shop without merchant intervention.
+
+**How it works:**
+1. During install/register, `ps_mbo` creates a dedicated MBO admin employee on the
+   shop and keeps a session alive for that employee.
+2. `mbo.prestashop.com` calls the shop's back-office URL directly (e.g.,
+   `https://shop.example.com/admin123/`), authenticated as this MBO employee.
+3. Requests are protected by HMAC signature (`src/Api/Security/`).
+4. `apiPsMbo.php` dispatches actions via `ModuleTransitionExecutor`; `apiSecurityPsMbo.php`
+   handles signature verification.
+
+**Known limitations (by design on 4.x):**
+- Calls fail when hosting/Cloudflare blocks back-office direct access
+- Network restrictions (closed firewalls, VPN) can prevent MBO from reaching the shop
+- This mechanism was removed in v5/PS9 in favour of simpler shop-side polling
+
+Files:
+- `controllers/admin/apiPsMbo.php` and `apiSecurityPsMbo.php`: legacy-style PS controllers
+- `src/Api/`: HMAC verifier, `AbstractAdminApiController`, `ModuleTransitionExecutor`, `ConfigApplyExecutor`
+
+### Tab System
+
+The 4.x branch registers PS back-office tabs via `src/Tab/`:
+
+- `Tab` / `TabInterface`: value object for a single tab entry
+- `TabCollection` / `TabCollectionInterface`: typed list of tabs
+- `TabCollectionFactory` / `TabCollectionFactoryInterface`: builds the collection from config
+- `TabCollectionDecoderXml`: parses tab config from XML
+- `TabCollectionProvider` / `TabCollectionProviderInterface`: provides tabs to `HaveTabs`
+
+`HaveTabs::getTabs()` returns this collection so PrestaShop registers/unregisters
+tabs on install/uninstall.
+
+### CDC (Cross Domain Component)
+
+The Addons catalog UI is **not** built in this repo. It is a compiled JS bundle
+(`mbo-cdc.umd.js`) hosted on the MBO CDN (`MBO_CDC_URL` env var, default:
+`https://assets.prestashop3.com/dst/mbo/v1/mbo-cdc.umd.js`).
+
+`ps_mbo` injects this bundle into the PS back-office via hook templates
+(Smarty `.tpl` files in `views/templates/hook/`). `HaveCdcComponent::smartyDisplayTpl()`
+is the shared rendering method.
+
+Hooks that inject CDC content:
+- `hookDashboardZoneOne`: module catalog page (main zone)
+- `hookDashboardZoneTwo`: module catalog page (secondary zone)
+- `hookDashboardZoneThree`: module catalog page (third zone)
+- `hookDisplayAdminThemesListAfter`: theme catalog
+
+### Connection Toolbar (4.x only)
+
+`UseDisplayAdminAfterHeader` renders a toolbar in the PS back-office header that:
+- Shows MBO connection status (registered / not registered)
+- Provides a CTA to register the shop if not done
+- Displays a "MBO employee" explanation banner when the MBO admin user is active
+
+Related assets: `views/css/connection-toolbar.css`, `views/js/connection-toolbar.js`,
+`views/templates/hook/configure-toolbar.tpl`,
+`views/templates/hook/twig/explanation_mbo_employee.html.twig`,
+`views/templates/hook/twig/failed-api-user.html.twig`.
+
+### Module lifecycle (install/upgrade from Addons)
+
+`ps_mbo` intercepts the native PS module manager install and upgrade flows to
+download zips from Addons transparently:
+
+Two distinct paths depending on whether a `$source` is provided to `ModuleManager`:
+
+**Path A - source provided (e.g. Addons URL):**
+```
+ModuleManager::install($name, $source)
+  -> sourceFactory->getHandler($source)
+       -> AddonsUrlSourceHandler::canHandle($source) == true
+            -> AddonsUrlSourceRetriever::get($source)
+            -> ZipSourceHandler::handle($localZipPath)
+  hookActionBeforeInstallModule fires but does nothing (source already resolved)
+```
+
+**Path B - no source (module name only):**
+```
+ModuleManager::install($name, source=null)
+  -> no SourceHandler invoked
+  -> hookActionBeforeInstallModule fires
+       -> ActionsManager::install(moduleId)
+            -> Addons API download by module ID
+            -> native PS installer picks up the local zip
+```
+
+### Module collection / catalogue
+
+`src/Module/` provides the data layer for the hook that enriches the module list:
+- `Repository`: queries the local PS module database
+- `CollectionFactory` + `Collection`: builds typed module lists
+- `FiltersFactory` + `Filters`: filtering by status/category
+- `ModuleBuilder`: constructs `Module` VO from raw PS data
+- `Module` VO wraps the legacy `\Module` instance with a `ParameterBag`
+
+### Distribution API clients
+
+Two clients in `src/Distribution/`, both extending `BaseClient` (Guzzle + PSR-18):
+
+| Class | Auth | Use |
+|-------|------|-----|
+| `Client` | anonymous | public key rotation, event tracking |
+| `ConnectedClient` | Accounts JWT + Addons credentials | authenticated module catalogue |
+
+### Addons API client
+
+`src/Addons/ApiClient.php` handles zip downloads from
+`https://api-addons.prestashop.com`. Used by `ActionsManager` when resolving
+module sources before install/upgrade.
+
+### Symfony routes
+
+All routes prefixed under `/mbo/`:
+
+| Prefix | Controller | Purpose |
+|--------|-----------|---------|
+| `/mbo/modules/catalog` | `ModuleCatalogController` | module catalog |
+| `/mbo/modules/recommended` | `ModuleRecommendedController` | recommended modules panel |
+| `/mbo/modules/selection` | `ModuleSelectionController` | module selection (4.x only) |
+| `/mbo/themes/catalog` | `ThemeCatalogController` | theme catalog |
+| `/mbo/addons` | `AddonsController` | Addons-specific routes |
+
+### Service container
+
+Symfony DI defined in `config/services/` (YAML files + one `addons.php` for
+Addons-related services). `src/DependencyInjection/ContainerProvider.php`
+exposes the Symfony container to legacy PS code via `$this->get(ServiceClass::class)`.
+All services must be `public: true` for legacy compatibility.
+
+### Views
+
+- `views/templates/hook/*.tpl` - Smarty: CDC injection, recommended modules,
+  empty category messages, connection toolbar
+- `views/templates/hook/twig/` - Twig: MBO employee explanation, failed API user error
+- `views/templates/admin/` - Twig: error page, AJAX layout (used by Symfony controllers)
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MBO_CDC_URL` | `https://assets.prestashop3.com/dst/mbo/v1/mbo-cdc.umd.js` | CDC JS bundle URL |
+| `DISTRIBUTION_API_URL` | `https://mbo-api.prestashop.com` | MBO distribution API |
+| `ADDONS_API_URL` | `https://api-addons.prestashop.com` | Addons zip download API |
+| `PS_MBO_SENTRY_CREDENTIALS` | (DSN) | Error monitoring |
+| `PS_MBO_SENTRY_ENVIRONMENT` | `production` | Sentry env tag |
+
+## Key Commands
+
+```bash
+composer install          # install all dependencies (dev included)
+composer install --no-dev -o  # production install
+composer test             # run PHPUnit
+composer lint             # php-cs-fixer (dry-run diff)
+make build-zip            # local zip without dev artifacts
+```
+
+## Conventions
+
+- PSR-12, `declare(strict_types=1)` at top of every file
+- One hook = one trait in `src/Traits/Hooks/`; boot logic in `boot{TraitName}()`
+- All services `public: true` in DI config (PS legacy DI constraint)
+- No class overrides; hooks only
+- `HaveConfigurationPage.php` is deleted from production zips by CI and its
+  `use` statement is stripped from `ps_mbo.php` via `sed`; do not put
+  production-facing logic in that file
+
+## CI / Artifacts
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `build-release.yml` | push/PR/release | builds composer, creates zip, uploads to GCS (preprod) or GitHub release (prod) |
+| `php.yml` | PR | php-linter, php-cs-fixer, phpstan, phpunit |
+| `translations.yml` | push to 4.x | Crowdin sync |
+| `install-mydemoshop.yml` | manual | test install on a live demo shop |
+
+AI context files (`.ai-tools/`, `.claude/`, `CLAUDE.md`) are excluded from
+all zip artifacts by CI and `make build-zip`.
+
+## Skills
+
+Project-specific skills live in `.claude/skills/`. Invoke them with the Skill tool or `/skill-name`:
+
+| Skill | Trigger |
+|-------|---------|
+| `release-versioning` | Version bump + GitHub release for 4.x. No `--latest` flag — v5/master is the canonical latest. |
+
+## Points of Attention
+
+- **Remote management API**: calls from `mbo.prestashop.com` to the shop back-office
+  are blocked by some hosters (Cloudflare, closed firewalls). This is a known
+  limitation of the 4.x architecture; the mechanism was redesigned in v5.
+- The CDC URL is injected at runtime from the `.env` file; if the CDC JS
+  fails to load, `admin_mbo_module_cdc_error` renders a graceful fallback page
+- `ConnectedClient` requires a valid PS Accounts token; anonymous shops silently
+  fall back to `Client`
+- PHPStan config is in `tests/phpstan/`; baseline and custom rules live there
+- Sentry env vars use the `PS_MBO_` prefix (`PS_MBO_SENTRY_CREDENTIALS`,
+  `PS_MBO_SENTRY_ENVIRONMENT`) to avoid conflicts with other modules on shared servers

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ build-zip:
 	rm -rf /tmp/ps_mbo/.ai-tools
 	rm -rf /tmp/ps_mbo/.claude
 	rm -rf /tmp/ps_mbo/CLAUDE.md
+	rm -rf /tmp/ps_mbo/.t9n.yml
+	rm -rf /tmp/ps_mbo/.gitattributes
+	rm -rf /tmp/ps_mbo/.gitmodules
 	rm -rf /tmp/ps_mbo/_dev
 	rm -rf /tmp/ps_mbo/tests
 	rm -rf /tmp/ps_mbo/docker-compose.yml

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ build-zip:
 	rm -rf /tmp/ps_mbo/.editorconfig
 	rm -rf /tmp/ps_mbo/.git
 	rm -rf /tmp/ps_mbo/.github
+	rm -rf /tmp/ps_mbo/.ai-tools
+	rm -rf /tmp/ps_mbo/.claude
+	rm -rf /tmp/ps_mbo/CLAUDE.md
 	rm -rf /tmp/ps_mbo/_dev
 	rm -rf /tmp/ps_mbo/tests
 	rm -rf /tmp/ps_mbo/docker-compose.yml


### PR DESCRIPTION
## Summary

Backport of PR #869 from master, adapted for the 4.x architecture.

- Add `.ai-tools` submodule (`PrestaShopCorp/marketplace-ai-tools@main`)
- Add `CLAUDE.md` documenting 4.x-specific architecture:
  - Remote management API as an **active feature** (not legacy): HMAC-signed calls from `mbo.prestashop.com`, persistent MBO admin user, known hosters/Cloudflare limitations
  - Tab system (`src/Tab/`) as active code
  - 4.x-only hooks: `UseDisplayAdminAfterHeader`, `UseActionAdminControllerSetMedia`, `UseActionGetAdminToolbarButtons`, `hookDashboardZoneTwo`
  - Connection toolbar and MBO employee UI
  - Correct stack: PHP >=7.2.5, Symfony 5.x, firebase/php-jwt ^6.3
- Add `.claude/` with:
  - `settings.json`: allowed composer/make commands
  - `agents/code-reviewer.md`: adapted for PHP >=7.2.5 / Symfony 5.x / PS 8.x, `src/Api/` treated as active code
  - `rules/`: di-config, hook-traits (includes 4.x-only hooks), templates, testing
  - `skills/release-versioning/SKILL.md`: targets `4.x` branch, no `--latest` flag (v5/master is canonical latest)
- Add `.gitattributes` export-ignore for all AI context paths
- Exclude `.ai-tools/`, `.claude/`, `CLAUDE.md` from `build-release.yml` zip artifacts (both preprod and prod jobs)
- Exclude AI context paths from `make build-zip`

## Test plan

- [ ] CI php.yml passes (no PHP files touched)
- [ ] Production zip does not contain `.ai-tools/`, `.claude/`, or `CLAUDE.md`
- [ ] Submodule `.ai-tools/` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)