### PR TITLE
fix: exclude dev-only files from zip artifacts

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -76,9 +76,10 @@ jobs:
         run: |
           rm -f gha-*.json
 
-      - name: Remove AI context files
+      - name: Remove dev-only files
         run: |
           rm -rf .ai-tools/ .claude/ CLAUDE.md
+          rm -f .t9n.yml .gitattributes .gitmodules
 
       - name: Prepare the zip
         run: |
@@ -135,9 +136,10 @@ jobs:
           rm -f ./src/Traits/HaveConfigurationPage.php
           sed -i '/HaveConfigurationPage/d' ps_mbo.php
 
-      - name: Remove AI context files
+      - name: Remove dev-only files
         run: |
           rm -rf .ai-tools/ .claude/ CLAUDE.md
+          rm -f .t9n.yml .gitattributes .gitmodules
 
       - name: Prepare the production zip
         run: |

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ build-zip:
 	rm -rf /tmp/ps_mbo/.ai-tools
 	rm -rf /tmp/ps_mbo/.claude
 	rm -rf /tmp/ps_mbo/CLAUDE.md
+	rm -rf /tmp/ps_mbo/.t9n.yml
+	rm -rf /tmp/ps_mbo/.gitattributes
+	rm -rf /tmp/ps_mbo/.gitmodules
 	rm -rf /tmp/ps_mbo/_dev
 	rm -rf /tmp/ps_mbo/tests
 	rm -rf /tmp/ps_mbo/docker-compose.yml


### PR DESCRIPTION
## Summary

- Renames \"Remove AI context files\" step to \"Remove dev-only files\" in both preproduction and production CI jobs
- Adds `.t9n.yml`, `.gitattributes`, `.gitmodules` to the cleanup list in `build-release.yml` (both jobs)
- Mirrors the same exclusions in `Makefile`'s `build-zip` target for parity with CI

These files were present in the v5.2.3 release zip and should not be shipped in production artifacts.

## Test plan

- [ ] Verify next release zip does not contain `.t9n.yml`, `.gitattributes`, `.gitmodules`
- [ ] Verify preprod artifact also excludes these files
- [ ] Verify local `make build-zip` also excludes them

🤖 Generated with [Claude Code](https://claude.com/claude-code)