### PR TITLE
fix: correctness bugs on master (PS9) and hook convention [SM-438]

### DIFF
--- a/.claude/rules/hook-traits.md
+++ b/.claude/rules/hook-traits.md
@@ -27,11 +27,15 @@ Every hook trait must follow this order:
 - Display hooks (`hookDisplay*`, `hookDashboard*`): return type `false|string`, return `''` on error (not `false`)
 - Action hooks (`hookAction*`): typically `void` or `array`; document expected shape if array
 
-## NEVER let an exception escape a hook
+## Exception handling in hooks
 
-A hook is called inside a PrestaShop workflow (module install, page render, module list build...). An uncaught exception propagates up and breaks the entire workflow for the merchant, not just this module.
+The rule differs by hook type.
 
-**Every hook method must be wrapped in a top-level try/catch(\Throwable).** No exception — checked or unchecked — may bubble out.
+### Display, list, and rendering hooks
+
+A hook is called inside a PrestaShop workflow (page render, module list build...). An uncaught exception propagates up and breaks the entire workflow for the merchant, not just this module.
+
+**Every display/list/rendering hook must be wrapped in a top-level try/catch(\Throwable).** No exception may bubble out.
 
 ```php
 // WRONG — exception escapes, breaks the PS workflow
@@ -58,6 +62,33 @@ public function hookActionListModules(array $params): array
 ```
 
 Return a safe neutral value on failure: `''` for display hooks, `[]` for hooks returning arrays, the unmodified input for hooks enriching a list.
+
+### Lifecycle hooks: `actionBeforeInstallModule` and `actionBeforeUpgradeModule`
+
+These hooks are the **exception to the rule above**. PS9 `ModuleController::moduleAction()` wraps the entire dispatch in a try/catch and surfaces `$e->getMessage()` as the JSON error message shown to the merchant. Throwing is the documented way to abort an install/upgrade with a translated, user-facing reason.
+
+**Do NOT wrap the top-level body in try/catch(\Throwable) for these hooks.** Swallowing the exception would let PS Core continue past a failed Addons download and produce an opaque failure for the merchant.
+
+Service retrieval failures may still be caught individually (to report the error), but exceptions from the business operation (Addons download, ActionsManager) must propagate.
+
+```php
+// CORRECT for actionBefore*Module
+public function hookActionBeforeInstallModule(array $params): void
+{
+    try {
+        $client = $this->get(ApiClient::class);
+        if (null === $client) {
+            throw new ExpectedServiceNotFoundException('...');
+        }
+    } catch (\Exception $e) {
+        ErrorHelper::reportError($e);
+        return;
+    }
+
+    // Let this throw: PS9 ModuleController catches it and surfaces getMessage() to the merchant
+    $actionsManager->install($moduleId);
+}
+```
 
 ## Boot method
 

--- a/ps_mbo.php
+++ b/ps_mbo.php
@@ -19,7 +19,7 @@
  */
 
 declare(strict_types=1);
-if (!defined('_PS_VERSION_') || version_compare(_PS_VERSION_, '8.0.2', '<')) {
+if (!defined('_PS_VERSION_') || version_compare(_PS_VERSION_, '9.0.0', '<')) {
     return;
 }
 

--- a/src/Service/View/ContextBuilder.php
+++ b/src/Service/View/ContextBuilder.php
@@ -204,7 +204,7 @@ class ContextBuilder
             'module_name' => ':module',
         ];
 
-        if (in_array($action, ['install', 'upgrade'])) {
+        if (in_array($action, ['install', 'upgrade', 'upload'])) {
             $params['id'] = '_module_id_';
             $params['source'] = '_download_url_';
         }

--- a/src/Traits/HaveAddonsInstall.php
+++ b/src/Traits/HaveAddonsInstall.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\Module\Mbo\Traits;
+
+use PrestaShop\Module\Mbo\Addons\ApiClient;
+use PrestaShop\Module\Mbo\Exception\ExpectedServiceNotFoundException;
+use PrestaShop\Module\Mbo\Helpers\ErrorHelper;
+use PrestaShop\Module\Mbo\Module\ActionsManager;
+use PrestaShop\Module\Mbo\Service\HookExceptionHolder;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+trait HaveAddonsInstall
+{
+    /**
+     * Downloads and installs a module from the Addons API.
+     * Throws on install failure so callers (hookActionBefore*Module) can propagate
+     * the error to PS Core, which surfaces it as a user-facing message.
+     *
+     * @throws \Exception propagated from ActionsManager::install()
+     */
+    protected function downloadModuleFromAddons(string $moduleName): void
+    {
+        try {
+            /** @var ApiClient|null $addonsClient */
+            $addonsClient = $this->get(ApiClient::class);
+            if (null === $addonsClient) {
+                throw new ExpectedServiceNotFoundException('Unable to get Addons ApiClient');
+            }
+        } catch (\Exception $e) {
+            ErrorHelper::reportError($e);
+
+            return;
+        }
+
+        $moduleId = (int) \Tools::getValue('module_id');
+
+        if (!$moduleId) {
+            $addon = $addonsClient->getModuleByName($moduleName);
+
+            if (null === $addon || !isset($addon->product->id_product)) {
+                return;
+            }
+
+            $moduleId = (int) $addon->product->id_product;
+        }
+
+        try {
+            /** @var ActionsManager|null $actionsManager */
+            $actionsManager = $this->get(ActionsManager::class);
+            if (null === $actionsManager) {
+                throw new ExpectedServiceNotFoundException('Unable to get ActionsManager');
+            }
+        } catch (\Exception $e) {
+            ErrorHelper::reportError($e);
+
+            return;
+        }
+
+        try {
+            $actionsManager->install($moduleId);
+        } catch (\Exception $e) {
+            /** @var HookExceptionHolder $hookExceptionHolder */
+            $hookExceptionHolder = $this->get(HookExceptionHolder::class);
+            if (null !== $hookExceptionHolder) {
+                $hookExceptionHolder->holdException('actionBeforeInstallModule', $e);
+            }
+
+            throw $e;
+        }
+    }
+}

--- a/src/Traits/Hooks/UseActionBeforeInstallModule.php
+++ b/src/Traits/Hooks/UseActionBeforeInstallModule.php
@@ -21,11 +21,9 @@ declare(strict_types=1);
 
 namespace PrestaShop\Module\Mbo\Traits\Hooks;
 
-use PrestaShop\Module\Mbo\Addons\ApiClient;
 use PrestaShop\Module\Mbo\Exception\ExpectedServiceNotFoundException;
 use PrestaShop\Module\Mbo\Helpers\ErrorHelper;
-use PrestaShop\Module\Mbo\Module\ActionsManager;
-use PrestaShop\Module\Mbo\Service\HookExceptionHolder;
+use PrestaShop\Module\Mbo\Traits\HaveAddonsInstall;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
 use PrestaShop\PrestaShop\Core\File\Exception\FileNotFoundException;
 use PrestaShop\PrestaShop\Core\Module\SourceHandler\SourceHandlerNotFoundException;
@@ -36,6 +34,7 @@ if (!defined('_PS_VERSION_')) {
 
 trait UseActionBeforeInstallModule
 {
+    use HaveAddonsInstall;
     /**
      * Hook actionBeforeInstallModule.
      *
@@ -62,52 +61,6 @@ trait UseActionBeforeInstallModule
 
         $moduleName = (string) $params['moduleName'];
 
-        try {
-            /** @var ApiClient|null $addonsClient */
-            $addonsClient = $this->get(ApiClient::class);
-            if (null === $addonsClient) {
-                throw new ExpectedServiceNotFoundException('Unable to get Addons ApiClient');
-            }
-        } catch (\Exception $e) {
-            ErrorHelper::reportError($e);
-
-            return;
-        }
-
-        $moduleId = (int) \Tools::getValue('module_id');
-
-        if (!$moduleId) {
-            $addon = $addonsClient->getModuleByName($moduleName);
-
-            if (null === $addon || !isset($addon->product->id_product)) {
-                return;
-            }
-
-            $moduleId = (int) $addon->product->id_product;
-        }
-
-        try {
-            /** @var ActionsManager|null $actionsManager */
-            $actionsManager = $this->get(ActionsManager::class);
-            if (null === $actionsManager) {
-                throw new ExpectedServiceNotFoundException('Unable to get ActionsManager');
-            }
-        } catch (\Exception $e) {
-            ErrorHelper::reportError($e);
-
-            return;
-        }
-
-        try {
-            $actionsManager->install($moduleId);
-        } catch (\Exception $e) {
-            /** @var HookExceptionHolder $hookExceptionHolder */
-            $hookExceptionHolder = $this->get(HookExceptionHolder::class);
-            if (null !== $hookExceptionHolder) {
-                $hookExceptionHolder->holdException('actionBeforeInstallModule', $e);
-            }
-
-            throw $e;
-        }
+        $this->downloadModuleFromAddons($moduleName);
     }
 }

--- a/src/Traits/Hooks/UseActionBeforeUpgradeModule.php
+++ b/src/Traits/Hooks/UseActionBeforeUpgradeModule.php
@@ -52,23 +52,8 @@ trait UseActionBeforeUpgradeModule
 
         $moduleName = (string) $params['moduleName'];
 
-        try {
-            /** @var ModuleDataProvider|null $moduleDataProvider */
-            $moduleDataProvider = $this->get('prestashop.adapter.data_provider.module');
-            if (null !== $moduleDataProvider) {
-                $dbData = $moduleDataProvider->findByName($moduleName);
-                $onDiskModule = \Module::getInstanceByName($moduleName);
-                if (
-                    $onDiskModule !== false
-                    && isset($dbData['version'])
-                    && version_compare((string) $onDiskModule->version, $dbData['version'], '>')
-                ) {
-                    // Avoid double download if already downloaded by SourceHandler in another request (upload => upgrade)
-                    return;
-                }
-            }
-        } catch (\Exception $e) {
-            ErrorHelper::reportError($e);
+        if ($this->isAlreadyDownloaded($moduleName)) {
+            return;
         }
 
         try {
@@ -121,6 +106,27 @@ trait UseActionBeforeUpgradeModule
 
         // Clear the cache after download to force reload module services
         $this->purgeCache();
+    }
+
+    private function isAlreadyDownloaded(string $moduleName): bool
+    {
+        try {
+            /** @var ModuleDataProvider|null $moduleDataProvider */
+            $moduleDataProvider = $this->get('prestashop.adapter.data_provider.module');
+            if (null === $moduleDataProvider) {
+                return false;
+            }
+            $dbData = $moduleDataProvider->findByName($moduleName);
+            $onDiskModule = \Module::getInstanceByName($moduleName);
+
+            return $onDiskModule !== false
+                && isset($dbData['version'])
+                && version_compare((string) $onDiskModule->version, $dbData['version'], '>');
+        } catch (\Exception $e) {
+            ErrorHelper::reportError($e);
+
+            return false;
+        }
     }
 
     private function purgeCache(): void

--- a/src/Traits/Hooks/UseActionBeforeUpgradeModule.php
+++ b/src/Traits/Hooks/UseActionBeforeUpgradeModule.php
@@ -27,6 +27,7 @@ use PrestaShop\Module\Mbo\Helpers\ErrorHelper;
 use PrestaShop\Module\Mbo\Module\ActionsManager;
 use PrestaShop\Module\Mbo\Service\HookExceptionHolder;
 use PrestaShop\PrestaShop\Adapter\Cache\Clearer\SymfonyCacheClearer;
+use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
 use PrestaShop\PrestaShop\Core\Cache\Clearer\CacheClearerInterface;
 use PrestaShop\PrestaShop\Core\File\Exception\FileNotFoundException;
 use PrestaShop\PrestaShop\Core\Module\SourceHandler\SourceHandlerNotFoundException;
@@ -45,13 +46,30 @@ trait UseActionBeforeUpgradeModule
      */
     public function hookActionBeforeUpgradeModule(array $params): void
     {
-        if (isset($params['source']) && !$params['source']) {
-            $this->purgeCache();
-
+        if (!empty($params['source'])) {
             return;
         }
 
         $moduleName = (string) $params['moduleName'];
+
+        try {
+            /** @var ModuleDataProvider|null $moduleDataProvider */
+            $moduleDataProvider = $this->get('prestashop.adapter.data_provider.module');
+            if (null !== $moduleDataProvider) {
+                $dbData = $moduleDataProvider->findByName($moduleName);
+                $onDiskModule = \Module::getInstanceByName($moduleName);
+                if (
+                    $onDiskModule !== false
+                    && isset($dbData['version'])
+                    && version_compare((string) $onDiskModule->version, $dbData['version'], '>')
+                ) {
+                    // Avoid double download if already downloaded by SourceHandler in another request (upload => upgrade)
+                    return;
+                }
+            }
+        } catch (\Exception $e) {
+            ErrorHelper::reportError($e);
+        }
 
         try {
             /** @var ApiClient|null $addonsClient */

--- a/src/Traits/Hooks/UseActionBeforeUpgradeModule.php
+++ b/src/Traits/Hooks/UseActionBeforeUpgradeModule.php
@@ -21,11 +21,9 @@ declare(strict_types=1);
 
 namespace PrestaShop\Module\Mbo\Traits\Hooks;
 
-use PrestaShop\Module\Mbo\Addons\ApiClient;
 use PrestaShop\Module\Mbo\Exception\ExpectedServiceNotFoundException;
 use PrestaShop\Module\Mbo\Helpers\ErrorHelper;
-use PrestaShop\Module\Mbo\Module\ActionsManager;
-use PrestaShop\Module\Mbo\Service\HookExceptionHolder;
+use PrestaShop\Module\Mbo\Traits\HaveAddonsInstall;
 use PrestaShop\PrestaShop\Adapter\Cache\Clearer\SymfonyCacheClearer;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
 use PrestaShop\PrestaShop\Core\Cache\Clearer\CacheClearerInterface;
@@ -38,6 +36,7 @@ if (!defined('_PS_VERSION_')) {
 
 trait UseActionBeforeUpgradeModule
 {
+    use HaveAddonsInstall;
     /**
      * Hook actionBeforeUpgradeModule.
      *
@@ -56,53 +55,7 @@ trait UseActionBeforeUpgradeModule
             return;
         }
 
-        try {
-            /** @var ApiClient|null $addonsClient */
-            $addonsClient = $this->get(ApiClient::class);
-            if (null === $addonsClient) {
-                throw new ExpectedServiceNotFoundException('Unable to get Addons ApiClient');
-            }
-        } catch (\Exception $e) {
-            ErrorHelper::reportError($e);
-
-            return;
-        }
-
-        $moduleId = (int) \Tools::getValue('module_id');
-
-        if (!$moduleId) {
-            $addon = $addonsClient->getModuleByName($moduleName);
-
-            if (null === $addon || !isset($addon->product->id_product)) {
-                return;
-            }
-
-            $moduleId = (int) $addon->product->id_product;
-        }
-
-        try {
-            /** @var ActionsManager|null $actionsManager */
-            $actionsManager = $this->get('mbo.modules.actions_manager');
-            if (null === $actionsManager) {
-                throw new ExpectedServiceNotFoundException('Unable to get ActionsManager');
-            }
-        } catch (\Exception $e) {
-            ErrorHelper::reportError($e);
-
-            return;
-        }
-
-        try {
-            $actionsManager->install($moduleId);
-        } catch (\Exception $e) {
-            /** @var HookExceptionHolder $hookExceptionHolder */
-            $hookExceptionHolder = $this->get('mbo.hook_exception_holder');
-            if (null !== $hookExceptionHolder) {
-                $hookExceptionHolder->holdException('actionBeforeInstallModule', $e);
-            }
-
-            throw $e;
-        }
+        $this->downloadModuleFromAddons($moduleName);
 
         // Clear the cache after download to force reload module services
         $this->purgeCache();

--- a/src/Traits/Hooks/UseActionBeforeUpgradeModule.php
+++ b/src/Traits/Hooks/UseActionBeforeUpgradeModule.php
@@ -55,7 +55,7 @@ trait UseActionBeforeUpgradeModule
 
         try {
             /** @var ApiClient|null $addonsClient */
-            $addonsClient = $this->get('mbo.addons.client.api');
+            $addonsClient = $this->get(ApiClient::class);
             if (null === $addonsClient) {
                 throw new ExpectedServiceNotFoundException('Unable to get Addons ApiClient');
             }

--- a/src/Traits/Hooks/UseActionBeforeUpgradeModule.php
+++ b/src/Traits/Hooks/UseActionBeforeUpgradeModule.php
@@ -113,7 +113,7 @@ trait UseActionBeforeUpgradeModule
         try {
             /** @var ModuleDataProvider|null $moduleDataProvider */
             $moduleDataProvider = $this->get('prestashop.adapter.data_provider.module');
-            if (null === $moduleDataProvider) {
+            if ($moduleDataProvider === null) {
                 return false;
             }
             $dbData = $moduleDataProvider->findByName($moduleName);


### PR DESCRIPTION
## Summary

- **Upgrade hook crash**: `UseActionBeforeUpgradeModule` was resolving `ApiClient` via string alias `'mbo.addons.client.api'` (undefined in container, returns `null`, fatals). Aligned on `ApiClient::class` to match the install hook.
- **Dead version guard**: `ps_mbo.php` entry guard checked `< 8.0.2` while `ps_versions_compliancy` declares `min = 9.0.0`. Updated to `9.0.0`.
- **Wrong hook convention**: `.claude/rules/hook-traits.md` had an absolute "never let exceptions escape" rule. That rule is wrong for `actionBeforeInstallModule` / `actionBeforeUpgradeModule`: PS9 `ModuleController` catches and surfaces `$e->getMessage()` as the merchant-facing error. Throwing is the documented abort mechanism. Convention updated with explicit lifecycle hook carve-out.
- **Double download on upgrade**: `hookActionBeforeUpgradeModule` was re-downloading the zip even when the CDC had already uploaded it via `AddonsUrlSourceHandler` (two-step flow: `/upload` then `/upgrade` with no source). Fixed with two guards: (1) `!empty($params['source'])` skips when any source handler already ran; (2) version comparison (`on-disk > DB`) skips when a prior upload placed the new version on disk.

## Test plan

- [x] Manual: install a module from Addons catalog (Path B, no source)
- [x] Manual: upgrade a module from Addons catalog — single download, no double fetch
- [x] Manual: upgrade a module via ZIP upload — no re-download from Addons

Closes SM-438

🤖 Generated with [Claude Code](https://claude.com/claude-code)