### PR TITLE
refactor(SM-441): centralize hook service resolution, drop dead bootHooks dispatch

### DIFF
--- a/.claude/rules/hook-traits.md
+++ b/.claude/rules/hook-traits.md
@@ -18,9 +18,9 @@ Every hook trait must follow this order:
 
 ## Service access
 
-- Always retrieve services via `$this->get(ServiceClass::class)`, never via `new`
-- After `$this->get()`, check for `null` and throw `ExpectedServiceNotFoundException` if required
-- Wrap service retrieval in try/catch; on exception call `ErrorHelper::reportError($e)` then return `''` (not `false`)
+- Retrieve required services via `$this->getRequiredService(ServiceClass::class)` (trait `Hooks\ResolvesServices`), never via `new`. It resolves from the container and throws `ExpectedServiceNotFoundException` when the service is missing, so callers no longer repeat the `get() + null-check + throw` boilerplate.
+- Use a `::class` reference where the service is registered by class name. PS-core ids without a class alias (e.g. the `router` service) are passed as a string id; keep a `@var` annotation on those calls for type narrowing.
+- Wrap service retrieval in try/catch; on exception call `ErrorHelper::reportError($e)` then return the safe neutral value (`''` for display hooks, not `false`).
 
 ## Hook return types
 
@@ -49,10 +49,7 @@ public function hookActionListModules(array $params): array
 public function hookActionListModules(array $params): array
 {
     try {
-        $service = $this->get(MyService::class);
-        if (null === $service) {
-            throw new ExpectedServiceNotFoundException('...');
-        }
+        $service = $this->getRequiredService(MyService::class);
         return $service->enrich($params['list']);
     } catch (\Throwable $e) {
         ErrorHelper::reportError($e);
@@ -76,10 +73,7 @@ Service retrieval failures may still be caught individually (to report the error
 public function hookActionBeforeInstallModule(array $params): void
 {
     try {
-        $client = $this->get(ApiClient::class);
-        if (null === $client) {
-            throw new ExpectedServiceNotFoundException('...');
-        }
+        $client = $this->getRequiredService(ApiClient::class);
     } catch (\Exception $e) {
         ErrorHelper::reportError($e);
         return;
@@ -89,10 +83,6 @@ public function hookActionBeforeInstallModule(array $params): void
     $actionsManager->install($moduleId);
 }
 ```
-
-## Boot method
-
-Each trait must have a `boot{TraitName}()` method (e.g. `bootUseDashboardZoneOne()`) called by `UseHooks::bootHooks()`. Put any per-hook service initialization here, not in the hook method itself.
 
 ## CDC-injecting hooks
 

--- a/.claude/rules/hook-traits.md
+++ b/.claude/rules/hook-traits.md
@@ -18,7 +18,7 @@ Every hook trait must follow this order:
 
 ## Service access
 
-- Retrieve required services via `$this->getRequiredService(ServiceClass::class)` (trait `Hooks\ResolvesServices`), never via `new`. It resolves from the container and throws `ExpectedServiceNotFoundException` when the service is missing, so callers no longer repeat the `get() + null-check + throw` boilerplate.
+- Retrieve required services via `$this->getRequiredService(ServiceClass::class)` (trait `Traits\ResolvesServices`), never via `new`. It resolves from the container and throws `ExpectedServiceNotFoundException` when the service is missing, so callers no longer repeat the `get() + null-check + throw` boilerplate.
 - Use a `::class` reference where the service is registered by class name. PS-core ids without a class alias (e.g. the `router` service) are passed as a string id; keep a `@var` annotation on those calls for type narrowing.
 - Wrap service retrieval in try/catch; on exception call `ErrorHelper::reportError($e)` then return the safe neutral value (`''` for display hooks, not `false`).
 

--- a/ps_mbo.php
+++ b/ps_mbo.php
@@ -93,10 +93,6 @@ class ps_mbo extends Module
                 'Modules.Mbo.Global'
             );
 
-        if (self::checkModuleStatus()) {
-            $this->bootHooks();
-        }
-
         $this->loadEnv();
     }
 

--- a/src/Traits/Hooks/ResolvesServices.php
+++ b/src/Traits/Hooks/ResolvesServices.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\Module\Mbo\Traits\Hooks;
+
+use PrestaShop\Module\Mbo\Exception\ExpectedServiceNotFoundException;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+trait ResolvesServices
+{
+    /**
+     * Resolve a required service from the container.
+     *
+     * Use a `::class` reference when the service is registered by class name; PS-core
+     * ids without a class alias (e.g. the `router` service) are passed as a string id,
+     * in which case the caller must keep its own `@var` annotation for type narrowing.
+     *
+     * @template T of object
+     *
+     * @param class-string<T>|string $serviceId
+     *
+     * @return ($serviceId is class-string<T> ? T : object)
+     *
+     * @throws ExpectedServiceNotFoundException when the service is not found
+     */
+    protected function getRequiredService(string $serviceId): object
+    {
+        $service = $this->get($serviceId);
+
+        if (null === $service) {
+            throw new ExpectedServiceNotFoundException(sprintf('Service "%s" not found', $serviceId));
+        }
+
+        return $service;
+    }
+}

--- a/src/Traits/Hooks/UseActionBeforeInstallModule.php
+++ b/src/Traits/Hooks/UseActionBeforeInstallModule.php
@@ -21,7 +21,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\Module\Mbo\Traits\Hooks;
 
-use PrestaShop\Module\Mbo\Exception\ExpectedServiceNotFoundException;
 use PrestaShop\Module\Mbo\Helpers\ErrorHelper;
 use PrestaShop\Module\Mbo\Traits\HaveAddonsInstall;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
@@ -44,11 +43,7 @@ trait UseActionBeforeInstallModule
     public function hookActionBeforeInstallModule(array $params): void
     {
         try {
-            /** @var ModuleDataProvider|null $moduleDataProvider */
-            $moduleDataProvider = $this->get('prestashop.adapter.data_provider.module');
-            if (null === $moduleDataProvider) {
-                throw new ExpectedServiceNotFoundException('Unable to get ModuleDataProvider');
-            }
+            $moduleDataProvider = $this->getRequiredService(ModuleDataProvider::class);
         } catch (\Exception $e) {
             ErrorHelper::reportError($e);
 

--- a/src/Traits/Hooks/UseActionBeforeUpgradeModule.php
+++ b/src/Traits/Hooks/UseActionBeforeUpgradeModule.php
@@ -21,12 +21,10 @@ declare(strict_types=1);
 
 namespace PrestaShop\Module\Mbo\Traits\Hooks;
 
-use PrestaShop\Module\Mbo\Exception\ExpectedServiceNotFoundException;
 use PrestaShop\Module\Mbo\Helpers\ErrorHelper;
 use PrestaShop\Module\Mbo\Traits\HaveAddonsInstall;
 use PrestaShop\PrestaShop\Adapter\Cache\Clearer\SymfonyCacheClearer;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
-use PrestaShop\PrestaShop\Core\Cache\Clearer\CacheClearerInterface;
 use PrestaShop\PrestaShop\Core\File\Exception\FileNotFoundException;
 use PrestaShop\PrestaShop\Core\Module\SourceHandler\SourceHandlerNotFoundException;
 
@@ -64,11 +62,7 @@ trait UseActionBeforeUpgradeModule
     private function isAlreadyDownloaded(string $moduleName): bool
     {
         try {
-            /** @var ModuleDataProvider|null $moduleDataProvider */
-            $moduleDataProvider = $this->get('prestashop.adapter.data_provider.module');
-            if ($moduleDataProvider === null) {
-                return false;
-            }
+            $moduleDataProvider = $this->getRequiredService(ModuleDataProvider::class);
             $dbData = $moduleDataProvider->findByName($moduleName);
             $onDiskModule = \Module::getInstanceByName($moduleName);
 
@@ -85,11 +79,7 @@ trait UseActionBeforeUpgradeModule
     private function purgeCache(): void
     {
         try {
-            /** @var CacheClearerInterface|null $cacheClearer */
-            $cacheClearer = $this->get(SymfonyCacheClearer::class);
-            if (null === $cacheClearer) {
-                throw new ExpectedServiceNotFoundException('Unable to get MboCacheClearer service');
-            }
+            $cacheClearer = $this->getRequiredService(SymfonyCacheClearer::class);
         } catch (\Exception $e) {
             ErrorHelper::reportError($e);
 

--- a/src/Traits/Hooks/UseActionGetAlternativeSearchPanels.php
+++ b/src/Traits/Hooks/UseActionGetAlternativeSearchPanels.php
@@ -21,9 +21,9 @@ declare(strict_types=1);
 
 namespace PrestaShop\Module\Mbo\Traits\Hooks;
 
-use PrestaShop\Module\Mbo\Exception\ExpectedServiceNotFoundException;
 use PrestaShop\Module\Mbo\Helpers\ErrorHelper;
 use PrestaShop\PrestaShop\Core\Search\SearchPanel;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -43,10 +43,8 @@ trait UseActionGetAlternativeSearchPanels
     public function hookActionGetAlternativeSearchPanels(array $params): array
     {
         try {
-            $router = $this->context->controller->get('router');
-            if ($router == null) {
-                throw new ExpectedServiceNotFoundException('Unable to get router service');
-            }
+            /** @var UrlGeneratorInterface $router */
+            $router = $this->getRequiredService('router');
 
             $catalogUrl = $router->generate('admin_mbo_catalog_module', []);
         } catch (\Exception $e) {

--- a/src/Traits/Hooks/UseActionGetAlternativeSearchPanels.php
+++ b/src/Traits/Hooks/UseActionGetAlternativeSearchPanels.php
@@ -23,7 +23,7 @@ namespace PrestaShop\Module\Mbo\Traits\Hooks;
 
 use PrestaShop\Module\Mbo\Helpers\ErrorHelper;
 use PrestaShop\PrestaShop\Core\Search\SearchPanel;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Bundle\FrameworkBundle\Routing\Router;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -43,7 +43,7 @@ trait UseActionGetAlternativeSearchPanels
     public function hookActionGetAlternativeSearchPanels(array $params): array
     {
         try {
-            /** @var UrlGeneratorInterface $router */
+            /** @var Router $router */
             $router = $this->getRequiredService('router');
 
             $catalogUrl = $router->generate('admin_mbo_catalog_module', []);

--- a/src/Traits/Hooks/UseActionListModules.php
+++ b/src/Traits/Hooks/UseActionListModules.php
@@ -21,7 +21,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\Module\Mbo\Traits\Hooks;
 
-use PrestaShop\Module\Mbo\Exception\ExpectedServiceNotFoundException;
 use PrestaShop\Module\Mbo\Helpers\Config;
 use PrestaShop\Module\Mbo\Helpers\ErrorHelper;
 use PrestaShop\Module\Mbo\Module\CollectionFactory;
@@ -52,23 +51,11 @@ trait UseActionListModules
     public function hookActionListModules(): array
     {
         try {
-            /** @var FiltersFactory|null $filtersFactory */
-            $filtersFactory = $this->get(FiltersFactory::class);
-            /** @var CollectionFactory|null $collectionFactory */
-            $collectionFactory = $this->get(CollectionFactory::class);
-            /** @var Repository|null $moduleRepository */
-            $moduleRepository = $this->get(Repository::class);
-            /** @var Router|null $router */
-            $router = $this->get('router');
-
-            if (
-                null === $filtersFactory
-                || null === $collectionFactory
-                || null === $moduleRepository
-                || null === $router
-            ) {
-                throw new ExpectedServiceNotFoundException('Some services not found in UseActionListModules');
-            }
+            $filtersFactory = $this->getRequiredService(FiltersFactory::class);
+            $collectionFactory = $this->getRequiredService(CollectionFactory::class);
+            $moduleRepository = $this->getRequiredService(Repository::class);
+            /** @var Router $router */
+            $router = $this->getRequiredService('router');
         } catch (\Exception $exception) {
             ErrorHelper::reportError($exception);
 
@@ -134,12 +121,7 @@ trait UseActionListModules
     private function getAdditionalDescription(string $moduleUrl, string $moduleName): string
     {
         try {
-            /** @var Environment|null $twigEnvironment */
-            $twigEnvironment = $this->get(Environment::class);
-
-            if (null === $twigEnvironment) {
-                throw new ExpectedServiceNotFoundException('Unable to get Twig service');
-            }
+            $twigEnvironment = $this->getRequiredService(Environment::class);
         } catch (\Exception $exception) {
             ErrorHelper::reportError($exception);
 

--- a/src/Traits/Hooks/UseDashboardZoneOne.php
+++ b/src/Traits/Hooks/UseDashboardZoneOne.php
@@ -21,7 +21,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\Module\Mbo\Traits\Hooks;
 
-use PrestaShop\Module\Mbo\Exception\ExpectedServiceNotFoundException;
 use PrestaShop\Module\Mbo\Helpers\ErrorHelper;
 use PrestaShop\Module\Mbo\Service\View\ContextBuilder;
 use PrestaShop\Module\Mbo\Traits\HaveCdcComponent;
@@ -46,12 +45,7 @@ trait UseDashboardZoneOne
         $extraParams = self::getCdcMediaUrl();
 
         try {
-            /** @var ContextBuilder|null $contextBuilder */
-            $contextBuilder = $this->get('mbo.cdc.context_builder');
-
-            if (null === $contextBuilder) {
-                throw new ExpectedServiceNotFoundException('Some services not found in HaveCdcComponent');
-            }
+            $contextBuilder = $this->getRequiredService(ContextBuilder::class);
         } catch (\Exception $e) {
             ErrorHelper::reportError($e);
 

--- a/src/Traits/Hooks/UseDisplayAdminThemesListAfter.php
+++ b/src/Traits/Hooks/UseDisplayAdminThemesListAfter.php
@@ -21,7 +21,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\Module\Mbo\Traits\Hooks;
 
-use PrestaShop\Module\Mbo\Exception\ExpectedServiceNotFoundException;
 use PrestaShop\Module\Mbo\Helpers\ErrorHelper;
 use PrestaShop\Module\Mbo\Service\View\ContextBuilder;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
@@ -41,14 +40,9 @@ trait UseDisplayAdminThemesListAfter
     public function hookDisplayAdminThemesListAfter(): string
     {
         try {
-            /** @var ContextBuilder|null $contextBuilder */
-            $contextBuilder = $this->get(ContextBuilder::class);
-            /** @var Router|null $router */
-            $router = $this->get('router');
-
-            if (null === $contextBuilder || null === $router) {
-                throw new ExpectedServiceNotFoundException('Some services not found in UseDisplayAdminThemesListAfter');
-            }
+            $contextBuilder = $this->getRequiredService(ContextBuilder::class);
+            /** @var Router $router */
+            $router = $this->getRequiredService('router');
         } catch (\Exception $e) {
             ErrorHelper::reportError($e);
 

--- a/src/Traits/Hooks/UseDisplayDashboardTop.php
+++ b/src/Traits/Hooks/UseDisplayDashboardTop.php
@@ -21,7 +21,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\Module\Mbo\Traits\Hooks;
 
-use PrestaShop\Module\Mbo\Exception\ExpectedServiceNotFoundException;
 use PrestaShop\Module\Mbo\Helpers\ErrorHelper;
 use PrestaShop\Module\Mbo\Service\View\ContextBuilder;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -221,11 +220,8 @@ trait UseDisplayDashboardTop
         }
 
         try {
-            /** @var UrlGeneratorInterface|null $router */
-            $router = $this->get('prestashop.router');
-            if (null === $router) {
-                throw new ExpectedServiceNotFoundException('Some services not found in UseDisplayDashboardTop');
-            }
+            /** @var UrlGeneratorInterface $router */
+            $router = $this->getRequiredService('prestashop.router');
 
             $recommendedModulesUrl = $router->generate(
                 'admin_mbo_recommended_modules',
@@ -365,14 +361,8 @@ trait UseDisplayDashboardTop
     private function renderModuleManagerMessage(): string
     {
         try {
-            /** @var Environment|null $twig */
-            $twig = $this->get('twig');
-            /** @var ContextBuilder|null $contextBuilder */
-            $contextBuilder = $this->get(ContextBuilder::class);
-
-            if (null === $contextBuilder || null === $twig) {
-                throw new ExpectedServiceNotFoundException('Some services not found in UseDisplayAdminAfterHeader');
-            }
+            $twig = $this->getRequiredService(Environment::class);
+            $contextBuilder = $this->getRequiredService(ContextBuilder::class);
 
             $extraParams = self::getCdcMediaUrl();
 

--- a/src/Traits/Hooks/UseDisplayEmptyModuleCategoryExtraMessage.php
+++ b/src/Traits/Hooks/UseDisplayEmptyModuleCategoryExtraMessage.php
@@ -22,7 +22,6 @@ declare(strict_types=1);
 namespace PrestaShop\Module\Mbo\Traits\Hooks;
 
 use PrestaShop\Module\Mbo\Addons\Provider\LinksProvider;
-use PrestaShop\Module\Mbo\Exception\ExpectedServiceNotFoundException;
 use PrestaShop\Module\Mbo\Helpers\ErrorHelper;
 use Twig\Environment;
 
@@ -41,14 +40,8 @@ trait UseDisplayEmptyModuleCategoryExtraMessage
         $categoryName = $params['category_name'];
 
         try {
-            /** @var Environment|null $twig */
-            $twig = $this->get(Environment::class);
-            /** @var LinksProvider|null $linksProvider */
-            $linksProvider = $this->get(LinksProvider::class);
-
-            if (null === $linksProvider || null === $twig) {
-                throw new ExpectedServiceNotFoundException('Some services not found in UseDisplayEmptyModuleCategoryExtraMessage');
-            }
+            $twig = $this->getRequiredService(Environment::class);
+            $linksProvider = $this->getRequiredService(LinksProvider::class);
 
             return $twig->render(
                 '@Modules/ps_mbo/views/templates/hook/twig/module_manager_empty_category.html.twig', [

--- a/src/Traits/ResolvesServices.php
+++ b/src/Traits/ResolvesServices.php
@@ -19,7 +19,7 @@
  */
 declare(strict_types=1);
 
-namespace PrestaShop\Module\Mbo\Traits\Hooks;
+namespace PrestaShop\Module\Mbo\Traits;
 
 use PrestaShop\Module\Mbo\Exception\ExpectedServiceNotFoundException;
 

--- a/src/Traits/UseHooks.php
+++ b/src/Traits/UseHooks.php
@@ -30,6 +30,7 @@ if (!defined('_PS_VERSION_')) {
 
 trait UseHooks
 {
+    use Hooks\ResolvesServices;
     use Hooks\UseDashboardZoneOne;
     use Hooks\UseDashboardZoneThree {
         Hooks\UseDashboardZoneOne::smartyDisplayTpl insteadof \PrestaShop\Module\Mbo\Traits\Hooks\UseDashboardZoneThree;
@@ -41,20 +42,6 @@ trait UseHooks
     use Hooks\UseActionListModules;
     use Hooks\UseDisplayEmptyModuleCategoryExtraMessage;
     use Hooks\UseActionBeforeUpgradeModule;
-
-    /**
-     * Try to call the "bootHookClassName" method on each hook class.
-     *
-     * @return void
-     */
-    protected function bootHooks(): void
-    {
-        foreach ($this->getTraitNames() as $traitName) {
-            if (method_exists($this, "boot{$traitName}")) {
-                $this->{"boot{$traitName}"}();
-            }
-        }
-    }
 
     /**
      * Try to call the "hookClassNameExtraOperations" method on each hook class.

--- a/src/Traits/UseHooks.php
+++ b/src/Traits/UseHooks.php
@@ -30,7 +30,7 @@ if (!defined('_PS_VERSION_')) {
 
 trait UseHooks
 {
-    use Hooks\ResolvesServices;
+    use ResolvesServices;
     use Hooks\UseDashboardZoneOne;
     use Hooks\UseDashboardZoneThree {
         Hooks\UseDashboardZoneOne::smartyDisplayTpl insteadof \PrestaShop\Module\Mbo\Traits\Hooks\UseDashboardZoneThree;


### PR DESCRIPTION
## Context

Hook trait cleanup. The one-trait-per-hook architecture in `src/Traits/Hooks/` is sound but had accumulated two sources of friction: duplicated service-retrieval boilerplate, and a dead `bootHooks()` dispatch loop.

Jira: https://prestashop-jira.atlassian.net/browse/SM-441

## Changes

- **Shared service resolution.** New `Hooks\ResolvesServices` trait exposing `getRequiredService()`, pulled in by `UseHooks`. Replaces the copy-pasted `get() + null-check + ExpectedServiceNotFoundException` block in every hook trait. Callers keep their own try/catch (the exception semantics differ between display and lifecycle hooks).
- **`::class` standardization.** Services registered by class name now use `::class` (`ContextBuilder`, Twig `Environment`, `ModuleDataProvider`). Using `ModuleDataProvider::class` also drops the deprecated `prestashop.adapter.data_provider.module` alias (deprecated in PS 9.0). The PS-core `router` / `prestashop.router` services have no FQCN registration in core, so they stay as string ids with a `@var` annotation.
- **Dead boot dispatch removed.** `UseHooks::bootHooks()` and its call site in `ps_mbo.php` are gone: no trait ever implemented a `boot*()` method, so the dispatch loop walked a list of no-ops.
- **Rule updated.** `.claude/rules/hook-traits.md` now documents `getRequiredService` and drops the obsolete "Boot method" section.

Net: -34 lines.

## Deviations from the ticket

Three ticket assumptions were stale against current code:

1. The SM-438 `mbo.addons.client.api` string-id typo is **already gone**: the Addons download was moved into `HaveAddonsInstall` which uses `ApiClient::class`.
2. AC "all `::class`" cannot be fully met: the `router` service has no class registration in PS core, so it remains a string id.
3. The redundant `cdcErrorUrl` removal in `UseDisplayAdminThemesListAfter` is **not applied**: that hook renders via `$this->fetch()`, not `smartyDisplayTpl()`, so its assignment is the sole source feeding `recommended-themes.tpl`. Removing it would break the theme catalog CDC error path.

## Scope

Pure refactor. No hook contract changes from PS Core's perspective. Service ids stay stable for DI consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)