### PR TITLE
fix: hard-code module name to comply with Addons rules

### DIFF
--- a/ps_mbo.php
+++ b/ps_mbo.php
@@ -71,8 +71,8 @@ class ps_mbo extends Module
      */
     public function __construct()
     {
-        $this->name = self::MODULE_NAME;
         // This value must be hard-coded to respect Addons rules, so we must make sure that the const value is always synced with this one
+        $this->name = 'ps_mbo';
         $this->version = '5.3.0';
         $this->author = 'PrestaShop';
         $this->tab = 'administration';


### PR DESCRIPTION
$this->name must be a hard-coded literal, not self::MODULE_NAME, so Addons can statically read the module identifier. The const value stays synced with this literal.

<!-----------------------------------------------------------------------------
Thank you for contributing to the MBO project! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | dev / master / 3.x
| Description?      | Please be specific when describing the PR. <br> Every detail helps: Module and/or PS versions, browser/server configuration, etc. Feel free to add more information below this table.
| Type?             | bug fix / improvement / new feature / refacto / critical
| BC breaks?        | yes / no
| Deprecations?     | yes / no
| Fixed ticket?     | Fixes #{issue number here}.
| How to test?      | Please indicate how to best verify that this PR is correct.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
