### PR TITLE
fix: restore install/upgrade on PS 9.0.x (SM-521)

### DIFF
--- a/ps_mbo.php
+++ b/ps_mbo.php
@@ -41,6 +41,7 @@ class ps_mbo extends Module
     use PrestaShop\Module\Mbo\Traits\HaveTabs;
     use PrestaShop\Module\Mbo\Traits\UseHooks;
     use PrestaShop\Module\Mbo\Traits\HaveConfigurationPage;
+    use PrestaShop\Module\Mbo\Traits\ResolvesServices;
 
     public const MODULE_NAME = 'ps_mbo';
 

--- a/src/Service/View/ContextBuilder.php
+++ b/src/Service/View/ContextBuilder.php
@@ -184,17 +184,31 @@ class ContextBuilder
             'shop_business_sector' => $shopActivity['name'],
             'overrides_on_shop' => $overrideChecker->listOverridesFromPsDirectory(),
             'actions_token' => UrlHelper::getQueryParameterValue($mboResetUrl, '_token'),
-            'actions_url' => [
-                'install' => $this->generateActionUrl('install'),
-                'uninstall' => $this->generateActionUrl('uninstall'),
-                'delete' => $this->generateActionUrl('delete'),
-                'enable' => $this->generateActionUrl('enable'),
-                'disable' => $this->generateActionUrl('disable'),
-                'reset' => $this->generateActionUrl('reset'),
-                'upgrade' => $this->generateActionUrl('upgrade'),
-                'upload' => $this->generateActionUrl('upload'),
-            ],
+            'actions_url' => $this->getActionsUrl(),
         ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getActionsUrl(): array
+    {
+        $actionsUrl = [
+            'install' => $this->generateActionUrl('install'),
+            'uninstall' => $this->generateActionUrl('uninstall'),
+            'delete' => $this->generateActionUrl('delete'),
+            'enable' => $this->generateActionUrl('enable'),
+            'disable' => $this->generateActionUrl('disable'),
+            'reset' => $this->generateActionUrl('reset'),
+            'upgrade' => $this->generateActionUrl('upgrade'),
+        ];
+
+        // The 'upload' action on route admin_module_manage_action exists only since PS 9.1.0
+        if (version_compare(_PS_VERSION_, '9.1.0', '>=')) {
+            $actionsUrl['upload'] = $this->generateActionUrl('upload');
+        }
+
+        return $actionsUrl;
     }
 
     private function generateActionUrl(string $action): string

--- a/src/Traits/UseHooks.php
+++ b/src/Traits/UseHooks.php
@@ -30,7 +30,6 @@ if (!defined('_PS_VERSION_')) {
 
 trait UseHooks
 {
-    use ResolvesServices;
     use Hooks\UseDashboardZoneOne;
     use Hooks\UseDashboardZoneThree {
         Hooks\UseDashboardZoneOne::smartyDisplayTpl insteadof \PrestaShop\Module\Mbo\Traits\Hooks\UseDashboardZoneThree;


### PR DESCRIPTION
## Context

Two bugs broke `ps_mbo` install/upgrade on PrestaShop 9.0.x (module is compatible 9.0.0 - 9.1.4).

## Bug 1 — `ResolvesServices` registered as a bogus hook

`use ResolvesServices;` lived inside the `UseHooks` trait. `getTraitNames()` enumerates `class_uses(UseHooks::class)` and `getHooksNames()` only strips the `Use` prefix, so `ResolvesServices` was passed to `registerHook()`. PS then demanded a nonexistent `hookResolvesServices` method and aborted install/upgrade:

> Hook with the name ResolvesServices has been registered by ps_mbo, but the corresponding method hookResolvesServices has not been defined in the Module class.

**Fix:** move `use ResolvesServices;` onto the `ps_mbo` class. `getRequiredService()` stays available to the hook traits without being scanned as a hook.

## Bug 2 — `upload` route action throws on PS < 9.1.0

The `upload` action on route `admin_module_manage_action` only exists since PS 9.1.0. On 9.0.x, `generateActionUrl('upload')` threw `InvalidParameterException` and broke the module catalog page:

> Parameter "action" for route "admin_module_manage_action" must match "install|uninstall|enable|disable|reset|upgrade|delete" ("upload" given)

**Fix:** add the `upload` action URL only when `_PS_VERSION_ >= 9.1.0`.

## Test

Manual: install/upgrade ps_mbo on a 9.0.3 shop (both paths previously failed).

Jira: https://prestashop-jira.atlassian.net/browse/SM-521

🤖 Generated with [Claude Code](https://claude.com/claude-code)